### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+  "name": "theunnamedroads",
+  "install": "corepack enable && pnpm install --frozen-lockfile",
+  "terminals": [
+    {
+      "name": "astro-dev",
+      "command": "pnpm dev --host 0.0.0.0",
+      "description": "Astro dev server with hot reload on http://localhost:4321"
+    }
+  ],
+  "ports": [
+    {
+      "name": "astro dev",
+      "port": 4321
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `.cursor/environment.json` so Cloud Agents get a working dev environment for this Astro static site out of the box.

## Configuration

- **install**: `corepack enable && pnpm install --frozen-lockfile` — restores the exact locked dependency tree using the pinned `pnpm@9.12.2` (from `packageManager` in `package.json`).
- **terminals**: `astro-dev` running `pnpm dev --host 0.0.0.0` — the Astro dev server with hot reload on port 4321.
- **ports**: exposes `4321` (Astro dev server).

The default Cursor base image already provides Node 22 and Corepack, so no custom Dockerfile is needed.

## Validation

Local VM:

| Check | Result |
| --- | --- |
| `pnpm install --frozen-lockfile` | Passed |
| Install idempotence | Passed twice (2nd run: "Already up to date") |
| `pnpm build` (Vercel deploy command) | Passed — 192 pages built, Pagefind indexed 189 pages, IndexNow correctly skipped outside production |
| Dev server (`/` and `/projects/`) | HTTP 200 |

Fresh Cloud Agent booted from the tested draft build `bld-20260831-99913c1e...`:

| Check | Result |
| --- | --- |
| Node / pnpm versions | v22.14.0 / 9.12.2 |
| Committed `.cursor/environment.json` present | Yes |
| Dependencies pre-installed (916 pkgs) + idempotent install | Passed |
| `pnpm build` | `[build] Complete!`, Pagefind indexed 189 pages, IndexNow skipped |
| Dev server `/` and `/projects/` | HTTP 200 |

### Browser walkthrough (local dev server)

[astro_dev_site_walkthrough.mp4](https://cursor.com/agents/bc-43d60ad1-3412-4f9a-80fc-fcc263138cea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fastro_dev_site_walkthrough.mp4)

[Homepage rendered on the dev server](https://cursor.com/agents/bc-43d60ad1-3412-4f9a-80fc-fcc263138cea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)

Note: `pnpm lint` and `pnpm astro check` surface pre-existing formatting/type errors in the repo source. These are unrelated to the environment (the toolchains run correctly) and were left untouched.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43d60ad1-3412-4f9a-80fc-fcc263138cea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43d60ad1-3412-4f9a-80fc-fcc263138cea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

