### PR TITLE
Improve keyboard focus, reduced-motion, and search accessibility

### DIFF
--- a/src/components/AnnouncementBar.astro
+++ b/src/components/AnnouncementBar.astro
@@ -9,11 +9,14 @@ const LIST_UUID = 'e7f38861-4bc4-448d-85ae-376e7f7c2fb0'
   class="hidden w-full border-b border-slate-700/60 bg-slate-900/80 text-sm backdrop-blur-sm"
 >
   <div
-    class="mx-auto flex max-w-6xl flex-wrap items-center gap-3 px-4 py-2 sm:flex-nowrap"
+    class="mx-auto flex max-w-6xl items-center gap-2 px-3 py-1.5 sm:gap-3 sm:px-4 sm:py-2"
   >
-    <span class="min-w-0 flex-1 text-xs text-slate-300">
-      Weekly notes on AI systems, solo building, and the unnamed roads worth
-      taking.
+    <span class="min-w-0 flex-1 truncate text-xs text-slate-300">
+      <span class="sm:hidden">Weekly notes from the studio.</span>
+      <span class="hidden sm:inline"
+        >Weekly notes on AI systems, solo building, and the unnamed roads worth
+        taking.</span
+      >
     </span>
     <form
       action={LISTMONK_URL}
@@ -26,12 +29,14 @@ const LIST_UUID = 'e7f38861-4bc4-448d-85ae-376e7f7c2fb0'
         type="email"
         name="email"
         required
+        autocomplete="email"
+        aria-label="Email address"
         placeholder="your@email.com"
-        class="h-7 w-40 rounded border border-slate-600 bg-slate-800 px-2 text-xs text-slate-100 placeholder:text-slate-500 focus:border-accent focus:outline-none"
+        class="h-7 w-28 rounded border border-slate-600 bg-slate-800 px-2 text-xs text-slate-100 placeholder:text-slate-500 focus:border-accent focus:outline-none sm:w-40"
       />
       <button
         type="submit"
-        class="h-7 whitespace-nowrap rounded bg-indigo-500 px-3 text-xs font-semibold text-white transition-colors hover:bg-indigo-400"
+        class="h-7 whitespace-nowrap rounded bg-white px-3 text-xs font-semibold text-gray-900 transition-colors hover:bg-gray-200"
       >
         Subscribe
       </button>

--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -21,7 +21,7 @@
         id="name"
         name="name"
         required
-        class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+        class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent dark:border-gray-500 dark:bg-gray-800 dark:text-gray-100"
       />
     </div>
 
@@ -37,7 +37,8 @@
         id="email"
         name="email"
         required
-        class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+        autocomplete="email"
+        class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent dark:border-gray-500 dark:bg-gray-800 dark:text-gray-100"
       />
     </div>
 
@@ -53,7 +54,7 @@
         id="subject"
         name="subject"
         required
-        class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+        class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent dark:border-gray-500 dark:bg-gray-800 dark:text-gray-100"
       />
     </div>
 
@@ -70,7 +71,7 @@
         rows="6"
         required
         placeholder="Tell us about your project, idea, or how we can help..."
-        class="w-full resize-y rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+        class="w-full resize-y rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent dark:border-gray-500 dark:bg-gray-800 dark:text-gray-100"
       ></textarea>
     </div>
 

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -11,13 +11,14 @@ const frontmatter: PageLayoutProps['frontmatter'] = {
 
 <PageLayout {frontmatter}>
   <h1>{frontmatter.title}</h1>
+  <p class="mb-6 text-slate-400">Search posts, projects, and insights.</p>
   <search-input
     class="flex w-full flex-col items-center gap-4 sm:flex-row sm:justify-center sm:gap-8"
   >
     <label for="search-input" class="sr-only">Search the site</label>
     <input
       id="search-input"
-      type="text"
+      type="search"
       placeholder="Type to search"
       class="w-full rounded border border-accent p-4 sm:w-[50%]"
     />
@@ -46,15 +47,21 @@ const frontmatter: PageLayoutProps['frontmatter'] = {
             return
 
           const onInput = async () => {
-            const searchQuery = searchInput.value
+            const searchQuery = searchInput.value.trim()
 
-            if (searchQuery === '') clearBtn.classList.add('invisible')
-            else clearBtn.classList.remove('invisible')
+            if (searchQuery === '') {
+              clearBtn.classList.add('invisible')
+              resultsHeading.innerHTML = ''
+              resultsContainer.innerHTML = ''
+              return
+            }
+
+            clearBtn.classList.remove('invisible')
 
             const { results } = await window.pagefind.search(searchQuery)
 
             resultsHeading.innerHTML =
-              results.length > 0 ? `Results (${results.length})` : 'No Results'
+              results.length > 0 ? `Results (${results.length})` : 'No results'
 
             resultsContainer.innerHTML = ''
 

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -14,17 +14,20 @@ const frontmatter: PageLayoutProps['frontmatter'] = {
   <search-input
     class="flex w-full flex-col items-center gap-4 sm:flex-row sm:justify-center sm:gap-8"
   >
+    <label for="search-input" class="sr-only">Search the site</label>
     <input
       id="search-input"
       type="text"
       placeholder="Type to search"
       class="w-full rounded border border-accent p-4 sm:w-[50%]"
     />
-    <span id="search-clear" class="clickable invisible text-xl sm:text-base"
-      >Clear</span
+    <button
+      id="search-clear"
+      type="button"
+      class="clickable invisible text-xl sm:text-base">Clear</button
     >
   </search-input>
-  <h2 id="results-heading">{''}</h2>
+  <h2 id="results-heading" aria-live="polite">{''}</h2>
   <ul id="results-list" class="list-none p-0"></ul>
 </PageLayout>
 

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -5,6 +5,11 @@ import PageLayout, {
 import { generateTags, getTagUsage } from '@/util/tags'
 
 const tags = await generateTags()
+const tagsWithCount = (
+  await Promise.all(
+    tags.map(async ({ tag }) => ({ tag, count: await getTagUsage(tag) }))
+  )
+).sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
 
 const frontmatter: PageLayoutProps['frontmatter'] = {
   title: 'Tags',
@@ -16,19 +21,16 @@ const frontmatter: PageLayoutProps['frontmatter'] = {
   <slot />
   <h1 class="mb-6 text-3xl font-semibold sm:text-4xl">Tags</h1>
   <p class="mb-8 text-slate-400">Browse insights and articles by topic.</p>
-  <div class="flex flex-wrap gap-4 sm:gap-8">
+  <div class="flex flex-wrap gap-2 sm:gap-3">
     {
-      tags.map(({ tag, icon }) => (
+      tagsWithCount.map(({ tag, count }) => (
         <a
-          class="clickable flex flex-col items-center gap-1 no-underline"
+          class="inline-flex items-center gap-2 rounded-full border border-white/15 px-3 py-1.5 text-sm no-underline transition-colors hover:border-white/40 hover:text-accent"
           href={`/tags/${tag}`}
           data-astro-prefetch
         >
-          <span class={`iconify text-4xl sm:text-5xl ${icon}`} />
-
-          <span class="text-base font-normal sm:text-lg">
-            {tag} ({getTagUsage(tag)})
-          </span>
+          <span>{tag}</span>
+          <span class="tabular-nums text-slate-400">{count}</span>
         </a>
       ))
     }

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -19,11 +19,16 @@
     @apply text-sm sm:text-base;
   }
 
-  /* Better touch targets for mobile */
-  button, 
-  .clickable,
-  a {
-    @apply min-h-[44px] sm:min-h-0 min-w-[44px] sm:min-w-0 flex items-center justify-center;
+  /* Touch targets on chrome controls only — not inline prose links. */
+  button:not([disabled]),
+  .clickable {
+    @apply min-h-[44px] min-w-[44px] sm:min-h-0 sm:min-w-0;
+  }
+
+  header a,
+  footer a,
+  #mobile-nav a {
+    @apply min-h-[44px] sm:min-h-0;
   }
 
   /* Responsive images */
@@ -97,5 +102,26 @@
   img[data-img-embed=''],
   img[data-img-embed='true'] {
     @apply border-accent rounded border;
+  }
+
+  .prose h2#related-resources {
+    @apply mb-6 mt-16 border-t border-slate-800 pt-8 text-2xl font-semibold;
+  }
+
+  .prose h2#related-resources + ul {
+    @apply list-none space-y-3 pl-0;
+  }
+
+  .prose h2#related-resources + ul li {
+    @apply my-0;
+  }
+
+  .prose h2#related-resources + ul a {
+    @apply font-medium;
+  }
+
+  .prose h2#related-resources + ul a::before {
+    content: '→ ';
+    @apply text-slate-500;
   }
 }

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -46,6 +46,30 @@
   ::-webkit-scrollbar-thumb:hover {
     @apply bg-accent/100;
   }
+
+  /* Visible keyboard focus for interactive elements. `:where()` keeps
+     specificity at 0 so components using `focus:ring`/`focus:outline-none`
+     keep their own focus styling. */
+  :where(a, button, summary, [tabindex]):focus-visible {
+    outline: 2px solid rgb(var(--accent));
+    outline-offset: 3px;
+    border-radius: 3px;
+  }
+}
+
+/* Respect users who prefer reduced motion. */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }
 
 @layer utilities {
@@ -74,48 +98,4 @@
   img[data-img-embed='true'] {
     @apply border-accent rounded border;
   }
-
-  /* NOTE: `:has-text()` is not valid CSS and never matches in a browser, so the
-     rules below currently have no effect. Kept as-is (behavior unchanged); the
-     stylelint rule is disabled for this block until they are reimplemented. */
-  /* stylelint-disable selector-pseudo-class-no-unknown */
-  /* Pillar callout styling - blockquotes that start with "Part of our" */
-  .prose blockquote:has(> p:first-child strong:has-text("Part of our")) {
-    @apply border-l-4 border-accent bg-slate-900/70 rounded-r-lg p-6 my-8 not-italic;
-  }
-
-  .prose blockquote:has(> p:first-child strong:has-text("Part of our")) > p {
-    @apply text-slate-200 leading-relaxed;
-  }
-
-  .prose blockquote:has(> p:first-child strong:has-text("Part of our")) > p:first-child {
-    @apply font-semibold text-slate-100 mb-2;
-  }
-
-  .prose blockquote:has(> p:first-child strong:has-text("Part of our")) a {
-    @apply text-accent font-semibold hover:underline;
-  }
-
-  /* Related Resources section styling */
-  .prose h2:has-text("Related Resources") {
-    @apply mt-16 mb-6 text-2xl font-semibold text-slate-100 border-t border-slate-800 pt-8;
-  }
-
-  .prose h2:has-text("Related Resources") + ul {
-    @apply list-none pl-0 space-y-3;
-  }
-
-  .prose h2:has-text("Related Resources") + ul li {
-    @apply my-0;
-  }
-
-  .prose h2:has-text("Related Resources") + ul li a {
-    @apply text-accent font-medium hover:underline inline-flex items-center gap-2;
-  }
-
-  .prose h2:has-text("Related Resources") + ul li a::before {
-    content: "→";
-    @apply text-slate-500;
-  }
-  /* stylelint-enable selector-pseudo-class-no-unknown */
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Site-wide UI/UX pass after a full visual audit. Visual design was already consistent; this PR lands accessibility, interaction, and the remaining polish items from that audit.

## Changes

- **Keyboard focus** — global `:focus-visible` outline on links, buttons, and other interactive elements.
- **Reduced motion** — honor `prefers-reduced-motion` globally.
- **Inline links** — 44px touch targets apply to header/footer/buttons only, so article links stay inline on mobile instead of becoming stacked 44px boxes.
- **Announcement bar** — compact one-row layout on mobile, shorter copy, subscribe button matches the mono palette.
- **Tags** — chip cloud sorted by usage instead of a grid of identical tag icons.
- **Search** — real label, Clear as a button, `aria-live` results, empty-query state, short helper copy.
- **Contact form** — slightly stronger field borders, `autocomplete="email"`.
- **Related Resources** — valid CSS via heading id (`#related-resources`) instead of invalid `:has-text()`.

## Validation

| Check | Result |
| --- | --- |
| `pnpm check` | 0 errors, 0 warnings, 0 hints |
| Visual audit of main templates (desktop + mobile) | Layouts were already consistent; remaining issues addressed above |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43d60ad1-3412-4f9a-80fc-fcc263138cea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43d60ad1-3412-4f9a-80fc-fcc263138cea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

