### PR TITLE
Redesign: clean editorial UI with unified design system

### DIFF
--- a/src/components/AnnouncementBar.astro
+++ b/src/components/AnnouncementBar.astro
@@ -6,7 +6,8 @@ const LIST_UUID = 'e7f38861-4bc4-448d-85ae-376e7f7c2fb0'
 
 <div
   id="announcement-bar"
-  class="hidden w-full border-b border-slate-700/60 bg-slate-900/80 text-sm backdrop-blur-sm"
+  class="hidden w-full border-b text-sm backdrop-blur-sm"
+  style="border-color: rgba(255,255,255,0.06); background: rgba(17,17,20,0.9)"
 >
   <div
     class="mx-auto flex max-w-6xl items-center gap-2 px-3 py-1.5 sm:gap-3 sm:px-4 sm:py-2"
@@ -32,11 +33,13 @@ const LIST_UUID = 'e7f38861-4bc4-448d-85ae-376e7f7c2fb0'
         autocomplete="email"
         aria-label="Email address"
         placeholder="your@email.com"
-        class="h-7 w-28 rounded border border-slate-600 bg-slate-800 px-2 text-xs text-slate-100 placeholder:text-slate-500 focus:border-accent focus:outline-none sm:w-40"
+        class="h-7 w-28 rounded-full border px-2 text-xs focus:border-accent focus:outline-none sm:w-40"
+        style="border-color: rgba(255,255,255,0.1); background: rgba(255,255,255,0.05); color: #f0ebe3"
       />
       <button
         type="submit"
-        class="h-7 whitespace-nowrap rounded bg-white px-3 text-xs font-semibold text-gray-900 transition-colors hover:bg-gray-200"
+        class="h-7 whitespace-nowrap rounded-full bg-accent px-3 text-xs font-semibold transition-colors"
+        style="color: #08080a"
       >
         Subscribe
       </button>

--- a/src/components/HomepageShell.astro
+++ b/src/components/HomepageShell.astro
@@ -16,7 +16,6 @@ if (!homepageEntry) {
 }
 
 const homepageData = homepageEntry.data
-
 const projects = await getProjects()
 
 const featuredProjects = projects
@@ -66,10 +65,7 @@ const ventureProjects = featuredProjects.map((project) => {
       label: meta.statusLabel ?? 'Active',
       tone: meta.statusTone ?? 'active'
     },
-    metric: {
-      label: metricLabel,
-      value: metricValue
-    },
+    metric: { label: metricLabel, value: metricValue },
     href,
     ctaLabel
   }
@@ -81,188 +77,108 @@ const ventureCards =
 const getStatusBadgeClass = (tone: string) =>
   (
     ({
-      active: 'text-emerald-300 border-emerald-400/40 bg-emerald-500/10',
-      building: 'text-amber-300 border-amber-400/40 bg-amber-500/10',
-      exploring: 'text-sky-300 border-sky-400/40 bg-sky-500/10'
+      active: 'text-emerald-300 border-emerald-400/30 bg-emerald-500/10',
+      building: 'text-amber-300 border-amber-400/30 bg-amber-500/10',
+      exploring: 'text-sky-300 border-sky-400/30 bg-sky-500/10'
     }) as const
   )[tone as 'active' | 'building' | 'exploring'] ??
-  'text-emerald-300 border-emerald-400/40 bg-emerald-500/10'
+  'text-emerald-300 border-emerald-400/30 bg-emerald-500/10'
 
 const getStatusDotClass = (tone: string) =>
   (
     ({
-      active: 'bg-emerald-400 shadow-[0_0_12px_rgba(16,185,129,0.7)]',
-      building: 'bg-amber-400 shadow-[0_0_12px_rgba(251,191,36,0.7)]',
-      exploring: 'bg-sky-400 shadow-[0_0_12px_rgba(56,189,248,0.7)]'
+      active: 'bg-emerald-400',
+      building: 'bg-amber-400',
+      exploring: 'bg-sky-400'
     }) as const
-  )[tone as 'active' | 'building' | 'exploring'] ??
-  'bg-emerald-400 shadow-[0_0_12px_rgba(16,185,129,0.7)]'
+  )[tone as 'active' | 'building' | 'exploring'] ?? 'bg-emerald-400'
 
 const heroLoop = homepageData.hero.controlLoop
 ---
 
-<div class="homepage-shell space-y-16 sm:space-y-20">
-  <section
-    data-reveal
-    class="hero-shell relative overflow-hidden rounded-[32px] border border-white/10 px-6 py-12 text-white shadow-2xl sm:px-10 sm:py-16"
-  >
-    <div
-      class="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_20%_0%,rgba(255,145,77,0.2),transparent_50%),radial-gradient(ellipse_at_90%_20%,rgba(45,212,191,0.12),transparent_45%)]"
-      aria-hidden="true"
-    >
+<div class="homepage-shell space-y-12 sm:space-y-16 lg:space-y-20">
+  <!-- Hero -->
+  <section class="hero" data-reveal>
+    <p class="section-eyebrow">{homepageData.hero.eyebrow}</p>
+    <h1 class="hero-headline mt-3">{homepageData.hero.headline}</h1>
+    <p class="hero-lead">
+      <strong>{homepageData.hero.eyebrow}</strong>
+      {
+        homepageData.hero.eyebrowAfter && (
+          <> — {homepageData.hero.eyebrowAfter}</>
+        )
+      }
+    </p>
+    <div class="hero-ctas">
+      <a
+        href="#ventures"
+        class="btn-primary"
+        data-ph-event="cta_click"
+        data-ph-cta-id="hero_ventures"
+        data-ph-section="hero"
+      >
+        View portfolio
+      </a>
+      <a
+        href="/insights"
+        class="btn-secondary"
+        data-ph-event="cta_click"
+        data-ph-cta-id="hero_insights"
+        data-ph-section="hero"
+      >
+        Read Field Notes
+      </a>
     </div>
-    <div class="relative flex min-w-0 flex-col gap-8 lg:gap-10">
-      <header class="hero-brand space-y-3">
-        <h1
-          class="text-4xl font-bold leading-tight tracking-tight sm:text-5xl lg:text-6xl"
-        >
-          {homepageData.hero.headline}
-        </h1>
-        <p class="max-w-2xl text-base leading-relaxed text-white/80 sm:text-lg">
-          <span class="font-semibold text-[#ff914d]">
-            {homepageData.hero.eyebrow}
-          </span>
-          {
-            homepageData.hero.eyebrowAfter && (
-              <>
-                <span class="text-white/40"> · </span>
-                <span class="text-white/85">
-                  {homepageData.hero.eyebrowAfter}
-                </span>
-              </>
-            )
-          }
-        </p>
-      </header>
-      <div class="hero-org-glow w-full min-w-0">
-        <div class="hero-org-browser">
-          <div class="hero-org-titlebar">
-            <span class="hero-org-dots" aria-hidden="true">
-              <span class="hero-org-dot hero-org-dot--r"></span>
-              <span class="hero-org-dot hero-org-dot--y"></span>
-              <span class="hero-org-dot hero-org-dot--g"></span>
-            </span>
-            <p class="hero-org-window-title">
-              {heroLoop.windowTitle}
-            </p>
-          </div>
-          <div class="hero-org-frame">
-            <div class="hero-org-inner-head">
-              <span class="hero-org-platform">
-                {heroLoop.platformLabel}
-              </span>
-              <span class="hero-org-live">
-                <span class="hero-org-live-dot" aria-hidden="true"></span>
-                {heroLoop.liveLabel ?? 'LIVE'}
-              </span>
-            </div>
 
-            <div class="hero-loop">
-              <div class="hero-loop-operator">
-                <div class="hero-org-card hero-org-card--director">
-                  <div class="hero-org-card-top">
-                    {
-                      heroLoop.operator.icon && (
-                        <span
-                          class:list={[
-                            'iconify shrink-0 text-lg opacity-90',
-                            heroLoop.operator.icon
-                          ]}
-                        />
-                      )
-                    }
-                    <div class="min-w-0 flex-1">
-                      <p class="hero-org-card-sub">{heroLoop.operator.label}</p>
-                      <p class="hero-org-card-title">
-                        {heroLoop.operator.title}
-                      </p>
-                      <p class="hero-org-card-tag">
-                        {heroLoop.operator.detail}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <p class="hero-org-team-label">{heroLoop.loopLabel}</p>
-
-              <div class="hero-loop-steps" aria-label={heroLoop.loopLabel}>
-                {
-                  heroLoop.steps.map((step, index) => (
-                    <div class="hero-loop-step-wrap">
-                      <div class="hero-loop-step">
-                        <div class="hero-org-card hero-org-card--lead">
-                          <p class="hero-org-card-title">{step.label}</p>
-                          <p class="hero-org-card-desc">{step.detail}</p>
-                        </div>
-                      </div>
-                      {index < heroLoop.steps.length - 1 && (
-                        <span class="hero-loop-arrow" aria-hidden="true">
-                          →
-                        </span>
-                      )}
-                    </div>
-                  ))
-                }
-              </div>
-
-              <div class="hero-loop-gate">
-                <span class="hero-loop-gate-pill">{heroLoop.gate.label}</span>
-                <span class="hero-loop-gate-detail">{heroLoop.gate.detail}</span
-                >
-              </div>
-
-              <p class="hero-org-team-label">{heroLoop.portfolioLabel}</p>
-
-              <div class="hero-loop-portfolio">
-                {
-                  heroLoop.portfolio.href ? (
-                    <a
-                      href={heroLoop.portfolio.href}
-                      class="hero-org-card hero-org-card--agent hero-loop-portfolio-link"
-                      data-ph-event="cta_click"
-                      data-ph-cta-id="hero_portfolio"
-                      data-ph-section="control_loop"
-                    >
-                      <p class="hero-org-card-desc">
-                        {heroLoop.portfolio.detail}
-                      </p>
-                    </a>
-                  ) : (
-                    <div class="hero-org-card hero-org-card--agent">
-                      <p class="hero-org-card-desc">
-                        {heroLoop.portfolio.detail}
-                      </p>
-                    </div>
-                  )
-                }
-              </div>
-            </div>
-
-            <p class="hero-org-browser-footer">
-              {heroLoop.footerCaption}
-            </p>
-          </div>
-        </div>
+    <div class="loop-panel" aria-label={heroLoop.loopLabel}>
+      <div class="loop-header">
+        <span class="loop-label">{heroLoop.platformLabel}</span>
+        <span class="loop-live">
+          <span class="loop-live-dot" aria-hidden="true"></span>
+          {heroLoop.liveLabel ?? 'LIVE'}
+        </span>
       </div>
+      <p class="loop-label mb-3">{heroLoop.loopLabel}</p>
+      <div class="loop-steps">
+        {
+          heroLoop.steps.map((step) => (
+            <div class="loop-step">
+              <p class="loop-step-label">{step.label}</p>
+              <p class="loop-step-detail">{step.detail}</p>
+            </div>
+          ))
+        }
+      </div>
+      <div class="loop-gate">
+        <span class="loop-gate-pill">{heroLoop.gate.label}</span>
+        <span class="loop-gate-detail">{heroLoop.gate.detail}</span>
+      </div>
+      {
+        heroLoop.portfolio.href && (
+          <a
+            href={heroLoop.portfolio.href}
+            class="mt-3 inline-block text-sm font-medium text-accent transition-colors hover:underline"
+            data-ph-event="cta_click"
+            data-ph-cta-id="hero_portfolio"
+            data-ph-section="control_loop"
+          >
+            {heroLoop.portfolio.detail} →
+          </a>
+        )
+      }
     </div>
   </section>
 
+  <!-- Ventures -->
   <section id="ventures" class="section-shell space-y-8" data-reveal>
-    <div class="space-y-3">
-      <p class="text-xs uppercase tracking-[0.4em] text-accent/80">
-        {homepageData.ventures.eyebrow}
-      </p>
+    <header class="space-y-3">
+      <p class="section-eyebrow">{homepageData.ventures.eyebrow}</p>
       <div
         class="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between"
       >
         <div>
-          <h2 class="text-3xl font-semibold text-gray-900 dark:text-white">
-            {homepageData.ventures.title}
-          </h2>
-          <p class="max-w-2xl text-base text-gray-600 dark:text-gray-300">
-            {homepageData.ventures.description}
-          </p>
+          <h2 class="section-title">{homepageData.ventures.title}</h2>
+          <p class="section-lead mt-2">{homepageData.ventures.description}</p>
         </div>
         <div class="flex flex-wrap gap-2">
           {
@@ -272,16 +188,18 @@ const heroLoop = homepageData.hero.controlLoop
           }
         </div>
       </div>
-    </div>
+    </header>
+
     {
       homepageData.ventures.statusPolicy && (
-        <div class="grid gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 sm:grid-cols-3">
+        <div
+          class="grid gap-3 rounded-xl border p-4 sm:grid-cols-3"
+          style="border-color: var(--roads-border)"
+        >
           {homepageData.ventures.statusPolicy.items.map((item) => (
             <div>
-              <p class="text-xs uppercase tracking-[0.3em] text-accent">
-                {item.label}
-              </p>
-              <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">
+              <p class="section-eyebrow">{item.label}</p>
+              <p class="mt-1 text-sm" style="color: var(--roads-text-muted)">
                 {item.detail}
               </p>
             </div>
@@ -293,7 +211,6 @@ const heroLoop = homepageData.hero.controlLoop
               data-ph-event="cta_click"
               data-ph-cta-id="status_policy"
               data-ph-section="ventures"
-              data-ph-label="Status policy"
             >
               {homepageData.ventures.statusPolicy.title} →
             </a>
@@ -301,72 +218,67 @@ const heroLoop = homepageData.hero.controlLoop
         </div>
       )
     }
-    <div class="grid gap-6 lg:grid-cols-2">
+
+    <div class="grid gap-5 lg:grid-cols-2">
       {
         ventureCards.map((company, index) => (
           <article
             class="venture-card"
             data-reveal
-            style={`--reveal-delay:${index * 70}ms`}
+            style={`--reveal-delay:${index * 60}ms`}
           >
-            <div class="grid gap-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+            <div class="flex items-start justify-between gap-4">
               <div>
-                <p class="text-xs uppercase tracking-[0.4em] text-gray-500 dark:text-gray-400">
-                  {company.tag}
-                </p>
-                <h3 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">
+                <p class="section-eyebrow">{company.tag}</p>
+                <h3
+                  class="mt-1 text-xl font-semibold"
+                  style="color: var(--roads-text)"
+                >
                   {company.name}
                 </h3>
-                <p class="text-sm text-gray-500 dark:text-gray-400">
+                <p class="text-sm" style="color: var(--roads-text-soft)">
                   {company.focus}
                 </p>
               </div>
-              <div class="flex items-center justify-end">
+              <span
+                class={`status-pill ${getStatusBadgeClass(company.status.tone)}`}
+              >
                 <span
-                  class={`status-pill ${getStatusBadgeClass(company.status.tone)}`}
-                >
-                  <span
-                    class={`status-dot ${getStatusDotClass(company.status.tone)}`}
-                  />
-                  {company.status.label}
-                </span>
-              </div>
+                  class={`status-dot ${getStatusDotClass(company.status.tone)}`}
+                />
+                {company.status.label}
+              </span>
             </div>
-            <p class="mt-4 max-w-[48ch] text-base leading-relaxed text-gray-600 dark:text-gray-300">
+            <p
+              class="mt-4 text-sm leading-relaxed"
+              style="color: var(--roads-text-muted)"
+            >
               {company.summary}
             </p>
-            <div class="mt-6 flex flex-wrap items-center justify-between gap-4">
+            <div class="mt-5 flex items-center justify-between gap-4">
               <div>
-                <p class="text-xs uppercase tracking-[0.3em] text-gray-500">
+                <p
+                  class="text-xs uppercase tracking-wider"
+                  style="color: var(--roads-text-soft)"
+                >
                   {company.metric.label}
                 </p>
-                <p class="text-2xl font-semibold text-gray-900 dark:text-white">
+                <p
+                  class="text-lg font-semibold"
+                  style="color: var(--roads-text)"
+                >
                   {company.metric.value}
                 </p>
               </div>
               {company.href && (
                 <a
                   href={company.href}
-                  class="inline-flex items-center gap-2 text-sm font-semibold text-accent"
+                  class="text-sm font-semibold text-accent"
                   data-ph-event="venture_card_click"
                   data-ph-venture-id={company.name}
                   data-ph-section="ventures"
-                  data-ph-href={company.href}
                 >
-                  {company.ctaLabel ?? 'View venture'}
-                  <svg
-                    class="h-4 w-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M5 12h14M12 5l7 7-7 7"
-                    />
-                  </svg>
+                  {company.ctaLabel ?? 'View venture'} →
                 </a>
               )}
             </div>
@@ -376,67 +288,65 @@ const heroLoop = homepageData.hero.controlLoop
     </div>
   </section>
 
+  <!-- Company OS -->
   {
     homepageData.companyOs && (
       <section id="company-os" class="section-shell space-y-8" data-reveal>
-        <div class="grid gap-8 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start">
-          <div class="space-y-4">
-            <p class="text-xs uppercase tracking-[0.4em] text-accent/80">
-              {homepageData.companyOs.eyebrow}
-            </p>
-            <h2 class="text-3xl font-semibold text-gray-900 dark:text-white">
-              {homepageData.companyOs.title}
-            </h2>
-            <p class="max-w-2xl text-base text-gray-600 dark:text-gray-300">
-              {homepageData.companyOs.description}
-            </p>
-            <div class="flex flex-wrap gap-3 pt-2">
-              <a
-                href={homepageData.companyOs.primaryCta.href}
-                class="inline-flex items-center justify-center gap-2 rounded-2xl bg-accent px-5 py-2.5 text-sm font-semibold text-white"
-                data-ph-event="cta_click"
-                data-ph-cta-id="company_os_explainer"
-                data-ph-section="company_os"
-                data-ph-label={homepageData.companyOs.primaryCta.label}
+        <header class="space-y-3">
+          <p class="section-eyebrow">{homepageData.companyOs.eyebrow}</p>
+          <h2 class="section-title">{homepageData.companyOs.title}</h2>
+          <p class="section-lead">{homepageData.companyOs.description}</p>
+          <div class="flex flex-wrap gap-3 pt-2">
+            <a
+              href={homepageData.companyOs.primaryCta.href}
+              class="btn-primary"
+              data-ph-event="cta_click"
+              data-ph-cta-id="company_os_explainer"
+              data-ph-section="company_os"
+            >
+              {homepageData.companyOs.primaryCta.label}
+            </a>
+            <a
+              href={homepageData.companyOs.secondaryCta.href}
+              class="btn-secondary"
+              data-ph-event="cta_click"
+              data-ph-cta-id="company_os_services"
+              data-ph-section="company_os"
+            >
+              {homepageData.companyOs.secondaryCta.label}
+            </a>
+          </div>
+        </header>
+        <div
+          class="grid grid-cols-3 gap-3 rounded-xl border p-4 text-center"
+          style="border-color: var(--roads-border)"
+        >
+          {homepageData.companyOs.stats.map((stat) => (
+            <div>
+              <p
+                class="text-2xl font-semibold"
+                style="color: var(--roads-text)"
               >
-                {homepageData.companyOs.primaryCta.label}
-              </a>
-              <a
-                href={homepageData.companyOs.secondaryCta.href}
-                class="inline-flex items-center justify-center gap-2 rounded-2xl border border-white/20 px-5 py-2.5 text-sm font-semibold text-gray-900 dark:text-white"
-                data-ph-event="cta_click"
-                data-ph-cta-id="company_os_services"
-                data-ph-section="company_os"
-                data-ph-label={homepageData.companyOs.secondaryCta.label}
+                {stat.value}
+              </p>
+              <p
+                class="text-xs uppercase tracking-wider"
+                style="color: var(--roads-text-soft)"
               >
-                {homepageData.companyOs.secondaryCta.label}
-              </a>
+                {stat.label}
+              </p>
             </div>
-          </div>
-          <div class="grid grid-cols-3 gap-3 rounded-2xl border border-gray-200/60 bg-white/70 p-4 text-center dark:border-gray-800/70 dark:bg-gray-900/60">
-            {homepageData.companyOs.stats.map((stat) => (
-              <div>
-                <p class="text-2xl font-semibold text-gray-900 dark:text-white">
-                  {stat.value}
-                </p>
-                <p class="text-xs uppercase tracking-[0.3em] text-gray-500">
-                  {stat.label}
-                </p>
-              </div>
-            ))}
-          </div>
+          ))}
         </div>
         <div class="grid gap-4 md:grid-cols-3">
           {homepageData.companyOs.pillars.map((pillar, index) => (
             <div
               class="signal-card"
               data-reveal
-              style={`--reveal-delay:${index * 60}ms`}
+              style={`--reveal-delay:${index * 50}ms`}
             >
-              <p class="text-xs uppercase tracking-[0.3em] text-accent">
-                {pillar.label}
-              </p>
-              <p class="mt-2 text-base text-gray-800 dark:text-gray-100">
+              <p class="section-eyebrow">{pillar.label}</p>
+              <p class="mt-2 text-sm" style="color: var(--roads-text-muted)">
                 {pillar.detail}
               </p>
             </div>
@@ -446,80 +356,65 @@ const heroLoop = homepageData.hero.controlLoop
     )
   }
 
-  <section class="section-shell signals-grid" data-reveal>
-    <div class="space-y-4">
-      <p class="text-xs uppercase tracking-[0.4em] text-accent/80">
-        {homepageData.signals.eyebrow}
-      </p>
-      <div class="grid gap-6 lg:grid-cols-[minmax(0,0.8fr)_1fr]">
-        <div>
-          <h2 class="text-3xl font-semibold text-gray-900 dark:text-white">
-            {homepageData.signals.title}
-          </h2>
-          <p class="mt-3 text-base text-gray-600 dark:text-gray-300">
-            {homepageData.signals.description}
-          </p>
-          <div class="mt-6 flex flex-wrap gap-3">
-            {
-              homepageData.signals.tags.map((tag, index) => (
-                <span class="signal-tag" style={`--tag-index:${index}`}>
-                  {tag}
-                </span>
-              ))
-            }
+  <!-- Signals / Thesis -->
+  <section class="section-shell space-y-6" data-reveal>
+    <header class="space-y-3">
+      <p class="section-eyebrow">{homepageData.signals.eyebrow}</p>
+      <h2 class="section-title">{homepageData.signals.title}</h2>
+      <p class="section-lead">{homepageData.signals.description}</p>
+    </header>
+    <div class="flex flex-wrap gap-2">
+      {
+        homepageData.signals.tags.map((tag) => (
+          <span class="signal-tag">{tag}</span>
+        ))
+      }
+    </div>
+    <div class="grid gap-4 md:grid-cols-2">
+      {
+        homepageData.signals.highlights.map((highlight, index) => (
+          <div
+            class="signal-card"
+            data-reveal
+            style={`--reveal-delay:${index * 50}ms`}
+          >
+            <p class="section-eyebrow">{highlight.label}</p>
+            <p class="mt-2 text-sm" style="color: var(--roads-text-muted)">
+              {highlight.detail}
+            </p>
           </div>
-        </div>
-        <div class="grid gap-4">
-          {
-            homepageData.signals.highlights.map((highlight, index) => (
-              <div
-                class="signal-card"
-                data-reveal
-                style={`--reveal-delay:${index * 60}ms`}
-              >
-                <p class="text-xs uppercase tracking-[0.3em] text-gray-500">
-                  {highlight.label}
-                </p>
-                <p class="mt-2 text-base text-gray-800 dark:text-gray-100">
-                  {highlight.detail}
-                </p>
-              </div>
-            ))
-          }
-        </div>
-      </div>
+        ))
+      }
     </div>
   </section>
 
+  <!-- Operating System -->
   <section id="operating-system" class="section-shell space-y-8" data-reveal>
-    <div class="space-y-3">
-      <p class="text-xs uppercase tracking-[0.4em] text-accent/80">
-        {homepageData.operatingSystem.eyebrow}
-      </p>
-      <h2 class="text-3xl font-semibold text-gray-900 dark:text-white">
-        {homepageData.operatingSystem.title}
-      </h2>
-      <p class="max-w-2xl text-base text-gray-600 dark:text-gray-300">
-        {homepageData.operatingSystem.description}
-      </p>
-    </div>
+    <header class="space-y-3">
+      <p class="section-eyebrow">{homepageData.operatingSystem.eyebrow}</p>
+      <h2 class="section-title">{homepageData.operatingSystem.title}</h2>
+      <p class="section-lead">{homepageData.operatingSystem.description}</p>
+    </header>
     <ol class="os-timeline">
       {
         homepageData.operatingSystem.phases.map((phase, index) => (
           <li
             class="os-phase"
             data-reveal
-            style={`--reveal-delay:${index * 70}ms`}
+            style={`--reveal-delay:${index * 60}ms`}
           >
             <span class="os-phase-label">{phase.label}</span>
             <div>
-              <h3 class="text-xl font-semibold text-gray-900 dark:text-white">
+              <h3
+                class="text-lg font-semibold"
+                style="color: var(--roads-text)"
+              >
                 {phase.title}
               </h3>
-              <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+              <p class="mt-1 text-sm" style="color: var(--roads-text-muted)">
                 {phase.description}
               </p>
-              <p class="mt-3 text-xs uppercase tracking-[0.35em] text-accent">
+              <p class="mt-2 text-xs uppercase tracking-wider text-accent">
                 {phase.meta}
               </p>
             </div>
@@ -531,30 +426,28 @@ const heroLoop = homepageData.hero.controlLoop
 
   <ToolStackSection id="tools" data={homepageData.tools} />
 
+  <!-- Testimonials -->
   <section class="section-shell space-y-8" data-reveal>
-    <div class="space-y-3">
-      <p class="text-xs uppercase tracking-[0.4em] text-accent/80">
-        {homepageData.testimonials.eyebrow}
-      </p>
-      <h2 class="text-3xl font-semibold text-gray-900 dark:text-white">
-        {homepageData.testimonials.title}
-      </h2>
-      <p class="max-w-2xl text-base text-gray-600 dark:text-gray-300">
-        {homepageData.testimonials.description}
-      </p>
-    </div>
+    <header class="space-y-3">
+      <p class="section-eyebrow">{homepageData.testimonials.eyebrow}</p>
+      <h2 class="section-title">{homepageData.testimonials.title}</h2>
+      <p class="section-lead">{homepageData.testimonials.description}</p>
+    </header>
     <div class="grid gap-5 md:grid-cols-3">
       {
         homepageData.testimonials.quotes.map((quote, index) => (
           <blockquote
             class="quote-card"
             data-reveal
-            style={`--reveal-delay:${index * 60}ms`}
+            style={`--reveal-delay:${index * 50}ms`}
           >
-            <p class="text-base leading-relaxed text-gray-800 dark:text-gray-100">
-              “{quote.quote}”
+            <p
+              class="text-sm leading-relaxed"
+              style="color: var(--roads-text-muted)"
+            >
+              &ldquo;{quote.quote}&rdquo;
             </p>
-            <footer class="mt-4 text-sm text-gray-500">
+            <footer class="mt-3 text-xs" style="color: var(--roads-text-soft)">
               {quote.author} · {quote.role}
             </footer>
           </blockquote>
@@ -563,59 +456,60 @@ const heroLoop = homepageData.hero.controlLoop
     </div>
   </section>
 
-  <section class="section-shell about-section" data-reveal>
-    <div class="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
-      <div
-        class="rounded-3xl border border-gray-200/60 bg-white/70 p-8 dark:border-gray-800/80 dark:bg-gray-900/60"
-      >
-        <p class="text-xs uppercase tracking-[0.4em] text-accent/80">
-          {homepageData.about.eyebrow}
-        </p>
-        <h2 class="mt-3 text-3xl font-semibold text-gray-900 dark:text-white">
-          {homepageData.about.title}
-        </h2>
-        <p class="mt-2 text-base text-gray-500">
+  <!-- About -->
+  <section class="section-shell" data-reveal>
+    <div class="grid gap-8 lg:grid-cols-2">
+      <div>
+        <p class="section-eyebrow">{homepageData.about.eyebrow}</p>
+        <h2 class="section-title mt-2">{homepageData.about.title}</h2>
+        <p class="mt-1 text-sm" style="color: var(--roads-text-soft)">
           {homepageData.about.subtitle}
         </p>
-        <div class="mt-6 space-y-4">
+        <div class="mt-5 space-y-3">
           {
             homepageData.about.body.map((paragraph) => (
-              <p class="text-base text-gray-600 dark:text-gray-300">
+              <p
+                class="text-sm leading-relaxed"
+                style="color: var(--roads-text-muted)"
+              >
                 {paragraph}
               </p>
             ))
           }
         </div>
       </div>
-      <div class="space-y-6">
-        <div class="grid gap-4">
-          {
-            homepageData.about.pillars.map((pillar, index) => (
-              <div
-                class="rounded-2xl border border-gray-200/60 bg-white/60 p-5 text-gray-900 dark:border-gray-800/70 dark:bg-gray-900/60 dark:text-white"
-                data-reveal
-                style={`--reveal-delay:${index * 40}ms`}
-              >
-                <p class="text-xs uppercase tracking-[0.4em] text-accent/70">
-                  {pillar.title}
-                </p>
-                <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
-                  {pillar.detail}
-                </p>
-              </div>
-            ))
-          }
-        </div>
+      <div class="space-y-4">
+        {
+          homepageData.about.pillars.map((pillar, index) => (
+            <div
+              class="signal-card"
+              data-reveal
+              style={`--reveal-delay:${index * 40}ms`}
+            >
+              <p class="section-eyebrow">{pillar.title}</p>
+              <p class="mt-1 text-sm" style="color: var(--roads-text-muted)">
+                {pillar.detail}
+              </p>
+            </div>
+          ))
+        }
         <div
-          class="grid grid-cols-3 gap-3 rounded-2xl border border-gray-200/60 bg-white/70 p-4 text-center dark:border-gray-800/70 dark:bg-gray-900/60"
+          class="grid grid-cols-3 gap-3 rounded-xl border p-4 text-center"
+          style="border-color: var(--roads-border)"
         >
           {
             homepageData.about.stats.map((stat) => (
               <div>
-                <p class="text-2xl font-semibold text-gray-900 dark:text-white">
+                <p
+                  class="text-xl font-semibold"
+                  style="color: var(--roads-text)"
+                >
                   {stat.value}
                 </p>
-                <p class="text-xs uppercase tracking-[0.3em] text-gray-500">
+                <p
+                  class="text-xs uppercase tracking-wider"
+                  style="color: var(--roads-text-soft)"
+                >
                   {stat.label}
                 </p>
               </div>
@@ -626,44 +520,42 @@ const heroLoop = homepageData.hero.controlLoop
     </div>
   </section>
 
-  <section
-    class="contact-shell relative overflow-hidden rounded-3xl border border-gray-900/10 bg-gradient-to-br from-gray-900 via-gray-800 to-black p-10 text-white"
-    data-reveal
-  >
-    <div class="space-y-5 text-center">
-      <p class="text-xs uppercase tracking-[0.5em] text-white/50">
-        {homepageData.contact.eyebrow}
-      </p>
-      <h2 class="text-3xl font-semibold">{homepageData.contact.title}</h2>
-      <p class="mx-auto max-w-2xl text-base text-white/70">
-        {homepageData.contact.description}
-      </p>
-      <div class="flex flex-col justify-center gap-3 sm:flex-row">
-        <a
-          href={homepageData.contact.primaryCta.href}
-          class="inline-flex items-center justify-center gap-2 rounded-2xl bg-white px-6 py-3 font-semibold text-gray-900"
-          data-ph-event="cta_click"
-          data-ph-cta-id="contact_primary"
-          data-ph-section="contact"
-          data-ph-label={homepageData.contact.primaryCta.label}
-        >
-          {homepageData.contact.primaryCta.label}
-        </a>
-        <a
-          href={homepageData.contact.secondaryCta.href}
-          class="inline-flex items-center justify-center gap-2 rounded-2xl border border-white/40 px-6 py-3 font-semibold text-white"
-          data-ph-event="cta_click"
-          data-ph-cta-id="contact_secondary"
-          data-ph-section="contact"
-          data-ph-label={homepageData.contact.secondaryCta.label}
-        >
-          {homepageData.contact.secondaryCta.label}
-        </a>
-      </div>
-      <p class="text-xs uppercase tracking-[0.4em] text-white/40">
-        {homepageData.contact.note}
-      </p>
+  <!-- Contact -->
+  <section class="contact-shell" data-reveal>
+    <p class="section-eyebrow">{homepageData.contact.eyebrow}</p>
+    <h2 class="section-title mt-3">{homepageData.contact.title}</h2>
+    <p
+      class="mx-auto mt-3 max-w-lg text-sm"
+      style="color: var(--roads-text-muted)"
+    >
+      {homepageData.contact.description}
+    </p>
+    <div class="mt-6 flex flex-col justify-center gap-3 sm:flex-row">
+      <a
+        href={homepageData.contact.primaryCta.href}
+        class="btn-primary"
+        data-ph-event="cta_click"
+        data-ph-cta-id="contact_primary"
+        data-ph-section="contact"
+      >
+        {homepageData.contact.primaryCta.label}
+      </a>
+      <a
+        href={homepageData.contact.secondaryCta.href}
+        class="btn-secondary"
+        data-ph-event="cta_click"
+        data-ph-cta-id="contact_secondary"
+        data-ph-section="contact"
+      >
+        {homepageData.contact.secondaryCta.label}
+      </a>
     </div>
+    <p
+      class="mt-4 text-xs uppercase tracking-wider"
+      style="color: var(--roads-text-soft)"
+    >
+      {homepageData.contact.note}
+    </p>
   </section>
 </div>
 
@@ -695,10 +587,7 @@ const heroLoop = homepageData.hero.controlLoop
           }
         })
       },
-      {
-        threshold: 0.15,
-        rootMargin: '0px 0px -10% 0px'
-      }
+      { threshold: 0.12, rootMargin: '0px 0px -8% 0px' }
     )
 
     elements.forEach((element) => {
@@ -716,1159 +605,3 @@ const heroLoop = homepageData.hero.controlLoop
   document.addEventListener('astro:page-load', registerReveal)
   document.addEventListener('astro:after-swap', registerReveal)
 </script>
-
-<style is:global>
-  :where(:root:not(.reveal-enabled)) [data-reveal] {
-    opacity: 1;
-    transform: none;
-  }
-
-  .reveal-enabled [data-reveal] {
-    opacity: 0;
-    transform: translateY(32px) scale(0.97);
-    transition:
-      opacity 0.8s ease,
-      transform 0.8s ease;
-    transition-delay: var(--reveal-delay, 0ms);
-  }
-
-  [data-reveal].is-visible {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-
-  .homepage-shell {
-    --tur-base: #01030b;
-    --tur-panel: rgba(6, 11, 26, 0.96);
-    --tur-panel-alt: rgba(10, 16, 34, 0.9);
-    --tur-panel-soft: rgba(17, 24, 56, 0.82);
-    --tur-border: rgba(148, 163, 184, 0.25);
-    --tur-border-soft: rgba(148, 163, 184, 0.14);
-    --tur-border-strong: rgba(255, 255, 255, 0.25);
-    --tur-text-strong: #f8fafc;
-    --tur-text-muted: rgba(226, 232, 240, 0.84);
-    --tur-text-soft: rgba(148, 163, 184, 0.68);
-    --tur-amber: #ff914d;
-    --tur-cyan: #4be1ff;
-    --tur-violet: #c084fc;
-    color: var(--tur-text-muted);
-  }
-
-  .hero-shell {
-    box-shadow:
-      0 55px 150px rgba(2, 6, 23, 0.85),
-      0 0 80px rgba(255, 145, 77, 0.06);
-    background:
-      radial-gradient(
-        circle at 18% 15%,
-        rgba(255, 145, 77, 0.14),
-        transparent 52%
-      ),
-      radial-gradient(
-        circle at 92% 8%,
-        rgba(45, 212, 191, 0.08),
-        transparent 42%
-      ),
-      #050814;
-  }
-
-  .hero-cta-primary {
-    background: linear-gradient(180deg, #ff9a5c 0%, #ff914d 55%, #ea580c 100%);
-    box-shadow: 0 12px 36px rgba(234, 88, 12, 0.35);
-  }
-
-  .hero-cta-primary:hover {
-    box-shadow: 0 14px 40px rgba(234, 88, 12, 0.45);
-  }
-
-  .hero-org-glow {
-    filter: drop-shadow(0 28px 48px rgba(0, 0, 0, 0.55));
-    width: 100%;
-  }
-
-  .hero-org-browser {
-    border-radius: 14px;
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    background: linear-gradient(
-      165deg,
-      rgba(22, 28, 42, 0.98),
-      rgba(12, 16, 28, 0.99)
-    );
-    box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.06),
-      0 24px 60px rgba(0, 0, 0, 0.45);
-    overflow: hidden;
-  }
-
-  .hero-org-titlebar {
-    display: flex;
-    align-items: center;
-    gap: 0.65rem;
-    padding: 0.55rem 0.85rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-    background: rgba(0, 0, 0, 0.25);
-  }
-
-  .hero-org-dots {
-    display: flex;
-    gap: 0.35rem;
-    flex-shrink: 0;
-  }
-
-  .hero-org-dot {
-    width: 9px;
-    height: 9px;
-    border-radius: 9999px;
-    display: block;
-  }
-
-  .hero-org-dot--r {
-    background: #ff5f57;
-  }
-
-  .hero-org-dot--y {
-    background: #febc2e;
-  }
-
-  .hero-org-dot--g {
-    background: #28c840;
-  }
-
-  .hero-org-window-title {
-    flex: 1;
-    text-align: center;
-    font-size: 0.68rem;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: rgba(255, 255, 255, 0.45);
-    margin: 0;
-    padding-right: 2.5rem;
-  }
-
-  .hero-org-frame {
-    padding: 0.65rem 0.75rem 0.5rem;
-  }
-
-  @media (min-width: 1024px) {
-    .hero-org-frame {
-      padding: 0.85rem 1.15rem 0.65rem;
-    }
-  }
-
-  .hero-org-inner-head {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 0.85rem;
-    padding: 0 0.15rem;
-  }
-
-  .hero-org-platform {
-    font-size: 0.62rem;
-    letter-spacing: 0.22em;
-    text-transform: uppercase;
-    color: rgba(255, 255, 255, 0.55);
-  }
-
-  .hero-org-live {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    font-size: 0.58rem;
-    font-weight: 600;
-    letter-spacing: 0.18em;
-    color: #4ade80;
-  }
-
-  .hero-org-live-dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 9999px;
-    background: #4ade80;
-    box-shadow: 0 0 10px rgba(74, 222, 128, 0.85);
-    animation: hero-live-pulse 2.2s ease-in-out infinite;
-  }
-
-  @keyframes hero-live-pulse {
-    50% {
-      opacity: 0.55;
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .hero-org-live-dot {
-      animation: none;
-    }
-  }
-
-  .hero-org-chart {
-    overflow: visible;
-    padding-right: 0;
-  }
-
-  @media (max-width: 1023px) {
-    .hero-org-chart {
-      max-height: min(62vh, 640px);
-      overflow-y: auto;
-      padding-right: 0.2rem;
-      scrollbar-width: thin;
-      scrollbar-color: rgba(255, 145, 77, 0.4) transparent;
-    }
-  }
-
-  .hero-org-tier--chief {
-    display: flex;
-    justify-content: center;
-    margin-bottom: 0.25rem;
-  }
-
-  .hero-org-tier--chief .hero-org-card {
-    max-width: 20rem;
-    width: 100%;
-  }
-
-  @media (min-width: 1280px) {
-    .hero-org-tier--chief .hero-org-card {
-      max-width: 24rem;
-    }
-  }
-
-  .hero-org-connector {
-    position: relative;
-    height: 1.75rem;
-    margin: 0 auto;
-    width: 100%;
-    max-width: min(100%, 72rem);
-  }
-
-  .hero-org-connector-v,
-  .hero-org-connector-h {
-    pointer-events: none;
-  }
-
-  .hero-org-flow-dot {
-    pointer-events: none;
-    border-radius: 9999px;
-    position: absolute;
-    z-index: 2;
-    background: #ecfdf5;
-    box-shadow:
-      0 0 6px rgba(74, 222, 128, 0.95),
-      0 0 14px rgba(255, 145, 77, 0.45);
-  }
-
-  .hero-org-flow-dot--v {
-    left: 50%;
-    width: 5px;
-    height: 5px;
-    margin-left: -2.5px;
-    top: 0;
-    animation: hero-org-flow-v 2.6s ease-in-out infinite;
-  }
-
-  .hero-org-flow-dot--v-delay {
-    animation-delay: 1.3s;
-  }
-
-  @keyframes hero-org-flow-v {
-    0% {
-      transform: translateY(0);
-      opacity: 0.15;
-    }
-
-    25% {
-      opacity: 1;
-    }
-
-    75% {
-      opacity: 1;
-    }
-
-    100% {
-      transform: translateY(calc(1.75rem - 5px));
-      opacity: 0.15;
-    }
-  }
-
-  .hero-org-flow-dot--h {
-    bottom: -1.5px;
-    width: 4px;
-    height: 4px;
-    margin-left: -2px;
-    animation: hero-org-flow-h-fwd 3.4s linear infinite;
-    animation-delay: var(--hero-h-delay, 0s);
-  }
-
-  .hero-org-flow-dot--h-rev {
-    animation-name: hero-org-flow-h-rev;
-  }
-
-  @keyframes hero-org-flow-h-fwd {
-    0% {
-      left: 2%;
-      opacity: 0;
-    }
-
-    12% {
-      opacity: 1;
-    }
-
-    88% {
-      opacity: 1;
-    }
-
-    100% {
-      left: 98%;
-      opacity: 0;
-    }
-  }
-
-  @keyframes hero-org-flow-h-rev {
-    0% {
-      left: 98%;
-      opacity: 0;
-    }
-
-    12% {
-      opacity: 1;
-    }
-
-    88% {
-      opacity: 1;
-    }
-
-    100% {
-      left: 2%;
-      opacity: 0;
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .hero-org-flow-dot--v,
-    .hero-org-flow-dot--h {
-      animation: none;
-      opacity: 0.45;
-    }
-
-    .hero-org-flow-dot--v {
-      transform: translateY(0.55rem);
-    }
-
-    .hero-org-flow-dot--h {
-      left: 50%;
-      opacity: 0.4;
-    }
-
-    .hero-org-flow-dot--h-rev {
-      left: 35%;
-    }
-  }
-
-  .hero-org-connector-v {
-    position: absolute;
-    left: 50%;
-    top: 0;
-    bottom: 0;
-    width: 2px;
-    transform: translateX(-50%);
-    background: linear-gradient(
-      to bottom,
-      rgba(255, 145, 77, 0.95),
-      rgba(255, 145, 77, 0.35)
-    );
-    border-radius: 9999px;
-  }
-
-  .hero-org-connector-h {
-    position: absolute;
-    left: 1%;
-    right: 1%;
-    height: 2px;
-    bottom: 0;
-    background: linear-gradient(
-      90deg,
-      transparent,
-      rgba(255, 145, 77, 0.65) 8%,
-      rgba(255, 145, 77, 0.65) 92%,
-      transparent
-    );
-    border-radius: 9999px;
-  }
-
-  .hero-org-team-label {
-    text-align: center;
-    font-size: 0.58rem;
-    letter-spacing: 0.35em;
-    text-transform: uppercase;
-    color: rgba(255, 145, 77, 0.85);
-    margin: 0.35rem 0 0.65rem;
-  }
-
-  .hero-org-exec-grid {
-    display: grid;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
-    gap: 0.45rem;
-    align-items: stretch;
-    width: 100%;
-  }
-
-  @media (min-width: 1024px) {
-    .hero-org-exec-grid {
-      gap: 0.65rem;
-    }
-  }
-
-  @media (min-width: 1280px) {
-    .hero-org-exec-grid {
-      gap: 0.85rem;
-    }
-  }
-
-  @media (max-width: 1023px) {
-    .hero-org-exec-grid {
-      grid-template-columns: repeat(5, minmax(100px, 1fr));
-      overflow-x: auto;
-      padding-bottom: 0.35rem;
-      -webkit-overflow-scrolling: touch;
-    }
-  }
-
-  .hero-org-col {
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-    min-width: 0;
-    min-height: 100%;
-  }
-
-  .hero-org-agent-stack {
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-  }
-
-  .hero-org-agent-stack--horizontal {
-    flex-direction: row;
-    flex-wrap: nowrap;
-    align-items: stretch;
-    gap: 0.3rem;
-    width: 100%;
-    margin-top: 0.15rem;
-    overflow-x: auto;
-    overflow-y: hidden;
-    -webkit-overflow-scrolling: touch;
-    padding-bottom: 0.15rem;
-    scrollbar-width: thin;
-    scrollbar-color: rgba(45, 212, 191, 0.45) transparent;
-  }
-
-  .hero-org-agent-stack--horizontal .hero-org-card--agent-compact {
-    flex: 1 1 0;
-    min-width: 4.5rem;
-  }
-
-  @media (min-width: 1280px) {
-    .hero-org-agent-stack--horizontal .hero-org-card--agent-compact {
-      min-width: 0;
-    }
-  }
-
-  .hero-org-card--agent-compact {
-    border-radius: 8px;
-    padding: 0.38rem 0.42rem 0.32rem !important;
-    border-width: 1px;
-  }
-
-  .hero-org-card-top--compact {
-    gap: 0.28rem;
-    align-items: flex-start;
-  }
-
-  .hero-org-agent-icon {
-    font-size: 0.85rem !important;
-    line-height: 1;
-  }
-
-  .hero-org-card-title--agent-compact {
-    font-size: 0.58rem !important;
-    font-weight: 700;
-    letter-spacing: 0.02em;
-    line-height: 1.2;
-    margin: 0;
-  }
-
-  .hero-org-card-sub--agent-compact {
-    font-size: 0.48rem !important;
-    margin: 0.08rem 0 0 !important;
-    line-height: 1.25;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
-
-  .hero-org-card-desc--agent-compact {
-    font-size: 0.45rem !important;
-    margin: 0.2rem 0 0 !important;
-    line-height: 1.3;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
-
-  .hero-org-status--agent-compact {
-    margin-top: 0.28rem !important;
-    padding-top: 0.25rem !important;
-    font-size: 0.42rem !important;
-    letter-spacing: 0.02em;
-    gap: 0.25rem;
-  }
-
-  .hero-org-status--agent-compact .hero-org-status-dot {
-    width: 4px;
-    height: 4px;
-  }
-
-  .hero-org-card {
-    border-radius: 10px;
-    padding: 0.55rem 0.55rem 0.45rem;
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    background: rgba(255, 255, 255, 0.04);
-  }
-
-  @media (min-width: 1024px) {
-    .hero-org-card {
-      padding: 0.65rem 0.7rem 0.5rem;
-      border-radius: 11px;
-    }
-  }
-
-  .hero-org-card--director {
-    border-color: rgba(148, 163, 184, 0.28);
-    background: rgba(15, 23, 42, 0.65);
-  }
-
-  .hero-org-card--lead {
-    border-color: rgba(74, 222, 128, 0.55);
-    background: rgba(74, 222, 128, 0.09);
-    box-shadow: 0 0 22px rgba(74, 222, 128, 0.12);
-    flex: 1 1 auto;
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-  }
-
-  .hero-org-card--lead .hero-org-card-top {
-    flex: 1 1 auto;
-  }
-
-  .hero-org-card--lead .hero-org-status {
-    margin-top: auto;
-    color: rgba(187, 247, 208, 0.88);
-    border-top-color: rgba(74, 222, 128, 0.22);
-  }
-
-  .hero-org-card--lead .hero-org-status-dot {
-    background: #4ade80;
-    box-shadow: 0 0 10px rgba(74, 222, 128, 0.75);
-  }
-
-  .hero-org-card--agent {
-    border-color: rgba(45, 212, 191, 0.45);
-    background: rgba(45, 212, 191, 0.07);
-    box-shadow: 0 0 14px rgba(45, 212, 191, 0.06);
-  }
-
-  .hero-org-card-top {
-    display: flex;
-    gap: 0.45rem;
-    align-items: flex-start;
-  }
-
-  .hero-org-card-title {
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    color: #f8fafc;
-    margin: 0;
-    line-height: 1.25;
-  }
-
-  @media (min-width: 1024px) {
-    .hero-org-card-title {
-      font-size: 0.78rem;
-    }
-  }
-
-  .hero-org-card-title--sm {
-    font-size: 0.65rem;
-  }
-
-  @media (min-width: 1024px) {
-    .hero-org-card-title--sm {
-      font-size: 0.7rem;
-    }
-  }
-
-  .hero-org-card-sub {
-    font-size: 0.58rem;
-    color: rgba(226, 232, 240, 0.72);
-    margin: 0.1rem 0 0;
-    line-height: 1.3;
-  }
-
-  .hero-org-card-sub--sm {
-    font-size: 0.54rem;
-  }
-
-  .hero-org-card-tag {
-    font-size: 0.55rem;
-    color: rgba(148, 163, 184, 0.88);
-    margin: 0.35rem 0 0;
-    line-height: 1.35;
-  }
-
-  .hero-org-card-desc {
-    font-size: 0.52rem;
-    color: rgba(148, 163, 184, 0.78);
-    margin: 0.3rem 0 0;
-    line-height: 1.35;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
-
-  .hero-org-status {
-    display: flex;
-    align-items: center;
-    gap: 0.35rem;
-    margin-top: 0.45rem;
-    padding-top: 0.4rem;
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
-    font-size: 0.52rem;
-    letter-spacing: 0.04em;
-    color: rgba(226, 232, 240, 0.65);
-  }
-
-  .hero-org-status--sm {
-    margin-top: 0.35rem;
-    padding-top: 0.3rem;
-    font-size: 0.48rem;
-  }
-
-  .hero-org-status-dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 9999px;
-    background: #facc15;
-    box-shadow: 0 0 8px rgba(250, 204, 21, 0.65);
-    flex-shrink: 0;
-  }
-
-  .hero-org-browser-footer {
-    margin: 0.65rem 0 0;
-    padding-top: 0.55rem;
-    border-top: 1px solid rgba(255, 255, 255, 0.06);
-    text-align: center;
-    font-size: 0.55rem;
-    letter-spacing: 0.28em;
-    text-transform: uppercase;
-    color: rgba(255, 255, 255, 0.35);
-  }
-
-  .hero-loop {
-    display: flex;
-    flex-direction: column;
-    gap: 0.65rem;
-  }
-
-  .hero-loop-operator {
-    display: flex;
-    justify-content: center;
-  }
-
-  .hero-loop-operator .hero-org-card {
-    max-width: 22rem;
-    width: 100%;
-  }
-
-  .hero-loop-steps {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: stretch;
-    justify-content: center;
-    gap: 0.25rem 0.15rem;
-  }
-
-  .hero-loop-step-wrap {
-    display: flex;
-    align-items: center;
-    gap: 0.15rem;
-  }
-
-  .hero-loop-step {
-    min-width: 4.5rem;
-    max-width: 6.5rem;
-  }
-
-  .hero-loop-step .hero-org-card {
-    padding: 0.45rem 0.5rem;
-    min-height: 100%;
-  }
-
-  .hero-loop-step .hero-org-card-title {
-    font-size: 0.62rem;
-  }
-
-  .hero-loop-step .hero-org-card-desc {
-    font-size: 0.48rem;
-    -webkit-line-clamp: 2;
-  }
-
-  .hero-loop-arrow {
-    color: rgba(255, 145, 77, 0.85);
-    font-size: 0.75rem;
-    line-height: 1;
-    padding: 0 0.05rem;
-  }
-
-  .hero-loop-gate {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    padding: 0.45rem 0.65rem;
-    border-radius: 9999px;
-    border: 1px dashed rgba(251, 191, 36, 0.45);
-    background: rgba(251, 191, 36, 0.08);
-  }
-
-  .hero-loop-gate-pill {
-    font-size: 0.58rem;
-    font-weight: 700;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    color: #fcd34d;
-  }
-
-  .hero-loop-gate-detail {
-    font-size: 0.52rem;
-    color: rgba(226, 232, 240, 0.75);
-  }
-
-  .hero-loop-portfolio {
-    display: block;
-  }
-
-  .hero-loop-portfolio-link {
-    display: block;
-    text-decoration: none;
-    transition:
-      border-color 0.2s ease,
-      transform 0.2s ease;
-  }
-
-  .hero-loop-portfolio-link:hover {
-    border-color: rgba(45, 212, 191, 0.65);
-    transform: translateY(-1px);
-  }
-
-  .hero-loop-portfolio .hero-org-card-desc {
-    margin: 0;
-    text-align: center;
-    font-size: 0.62rem;
-    line-height: 1.45;
-  }
-
-  @media (max-width: 640px) {
-    .hero-loop-steps {
-      overflow-x: auto;
-      flex-wrap: nowrap;
-      justify-content: flex-start;
-      padding-bottom: 0.25rem;
-    }
-
-    .hero-loop-step-wrap {
-      flex-shrink: 0;
-    }
-  }
-
-  .hero-quote {
-    margin: 0;
-  }
-
-  .hero-badge {
-    border-radius: 9999px;
-    border: 1px solid rgba(255, 255, 255, 0.25);
-    padding: 0.4rem 0.85rem;
-    background: rgba(255, 255, 255, 0.05);
-    font-size: 0.75rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-  }
-
-  .glass-panel {
-    min-height: 100%;
-  }
-
-  .hero-sheen {
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    background: radial-gradient(
-      circle at 50% 50%,
-      rgba(14, 165, 233, 0.2),
-      transparent 60%
-    );
-    filter: blur(25px);
-  }
-
-  .hero-panel {
-    border-radius: 28px;
-    border: 1px solid var(--tur-border-soft);
-    background: rgba(4, 7, 18, 0.7);
-    padding: 1.5rem;
-    backdrop-filter: blur(18px);
-  }
-
-  .hero-stats-grid {
-    display: flex;
-    flex-direction: column;
-    gap: 1.25rem;
-  }
-
-  .hero-stat {
-    border-radius: 20px;
-    border: 1px solid var(--tur-border-soft);
-    background: rgba(255, 255, 255, 0.04);
-    padding: 1rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-    min-height: 130px;
-    justify-content: center;
-    align-items: center;
-    text-align: center;
-  }
-
-  .hero-stat-label {
-    font-size: 0.65rem;
-    text-transform: uppercase;
-    letter-spacing: 0.35em;
-    color: rgba(255, 255, 255, 0.6);
-  }
-
-  .hero-stat-value {
-    font-size: clamp(2rem, 3vw, 2.75rem);
-    font-weight: 600;
-    color: var(--tur-text-strong);
-  }
-
-  .hero-stat-detail {
-    font-size: 0.95rem;
-    color: rgba(255, 255, 255, 0.7);
-  }
-
-  .hero-badge,
-  .hero-signal-chip,
-  .hero-highlight,
-  .hero-window-card {
-    color: inherit;
-  }
-
-  .hero-signal-chip {
-    border-radius: 9999px;
-    background: rgba(255, 255, 255, 0.08);
-    border: 1px solid rgba(255, 255, 255, 0.18);
-    padding: 0.35rem 0.9rem;
-    text-transform: uppercase;
-    letter-spacing: 0.2em;
-    font-size: 0.7rem;
-  }
-
-  .hero-highlight {
-    border-radius: 18px;
-    border: 1px solid var(--tur-border-soft);
-    background: rgba(255, 255, 255, 0.03);
-    padding: 1rem;
-  }
-
-  .hero-divider {
-    height: 1px;
-    width: 100%;
-    background: linear-gradient(
-      90deg,
-      transparent,
-      rgba(255, 255, 255, 0.35),
-      transparent
-    );
-  }
-
-  .hero-window-card {
-    border-radius: 18px;
-    border: 1px solid var(--tur-border-soft);
-    background: rgba(255, 255, 255, 0.03);
-    padding: 0.9rem 1rem;
-  }
-
-  .section-eyebrow {
-    font-size: 0.65rem;
-    text-transform: uppercase;
-    letter-spacing: 0.4em;
-    color: var(--tur-text-soft);
-  }
-
-  .section-shell {
-    border-radius: 32px;
-    border: 1px solid var(--tur-border);
-    background: linear-gradient(135deg, var(--tur-panel), rgba(3, 6, 18, 0.88));
-    padding: clamp(1.75rem, 3vw, 3rem);
-    box-shadow: 0 35px 90px rgba(2, 6, 23, 0.65);
-  }
-
-  .section-shell
-    :is(
-      .text-gray-900,
-      .text-slate-900,
-      .text-gray-800,
-      .text-slate-800,
-      .text-gray-700,
-      .text-slate-700,
-      .text-white
-    ) {
-    color: var(--tur-text-strong);
-  }
-
-  .section-shell
-    :is(.text-gray-600, .text-slate-600, .text-gray-500, .text-slate-500) {
-    color: var(--tur-text-muted);
-  }
-
-  .section-shell
-    :is(.text-gray-400, .text-slate-400, .text-gray-300, .text-slate-300) {
-    color: var(--tur-text-soft);
-  }
-
-  .filter-chip {
-    border-radius: 9999px;
-    border: 1px solid var(--tur-border);
-    padding: 0.35rem 1rem;
-    font-size: 0.75rem;
-    letter-spacing: 0.2em;
-    text-transform: uppercase;
-    color: var(--tur-text-muted);
-    background: rgba(255, 255, 255, 0.04);
-  }
-
-  .filter-chip:hover {
-    color: var(--tur-text-strong);
-    border-color: var(--tur-border-strong);
-  }
-
-  .venture-card {
-    border-radius: 28px;
-    border: 1px solid var(--tur-border);
-    background: var(--tur-panel-alt);
-    padding: 1.75rem;
-    position: relative;
-    overflow: hidden;
-  }
-
-  .venture-card::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    background: radial-gradient(
-      circle at top right,
-      rgba(255, 145, 77, 0.25),
-      transparent 55%
-    );
-    opacity: 0;
-    transition: opacity 0.3s ease;
-    pointer-events: none;
-  }
-
-  .venture-card:hover::after {
-    opacity: 1;
-  }
-
-  .status-pill {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    border-radius: 9999px;
-    border: 1px solid var(--tur-border-strong);
-    padding: 0.25rem 0.9rem;
-    font-size: 0.72rem;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    white-space: nowrap;
-  }
-
-  .status-dot {
-    width: 0.45rem;
-    height: 0.45rem;
-    border-radius: 9999px;
-    box-shadow: 0 0 12px currentColor;
-  }
-
-  .ai-status-pill {
-    display: inline-flex;
-    align-items: center;
-    border-radius: 9999px;
-    border: 1px solid var(--tur-border);
-    padding: 0.15rem 0.65rem;
-    font-size: 0.62rem;
-    letter-spacing: 0.25em;
-    text-transform: uppercase;
-    color: var(--tur-text-soft);
-  }
-
-  .ai-status-pill--active {
-    color: #34d399;
-    border-color: rgba(16, 185, 129, 0.4);
-    background: rgba(16, 185, 129, 0.08);
-  }
-
-  .ai-status-pill--hiring {
-    color: #facc15;
-    border-color: rgba(251, 191, 36, 0.35);
-    background: rgba(251, 191, 36, 0.08);
-  }
-
-  .signals-grid {
-    padding: clamp(1.75rem, 3vw, 3rem);
-  }
-
-  .signal-chip {
-    border-radius: 9999px;
-    border: 1px dashed var(--tur-border-soft);
-    padding: 0.4rem 0.95rem;
-    font-size: calc(0.75rem + (var(--signal-index, 0) * 0.01rem));
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    background: rgba(255, 255, 255, 0.04);
-    color: var(--tur-text-muted);
-  }
-
-  .signal-card {
-    border-radius: 20px;
-    border: 1px solid var(--tur-border-soft);
-    background: rgba(255, 255, 255, 0.03);
-    padding: 1.25rem;
-  }
-
-  .os-stack {
-    border-radius: 28px;
-    border: 1px solid var(--tur-border);
-    background: linear-gradient(
-      145deg,
-      var(--tur-panel-alt),
-      rgba(3, 6, 18, 0.85)
-    );
-    padding: 2rem;
-    color: var(--tur-text-muted);
-  }
-
-  .os-timeline {
-    position: relative;
-    border-left: 1px solid var(--tur-border-soft);
-    margin-left: 1.5rem;
-    padding-left: 2rem;
-  }
-
-  .os-phase {
-    position: relative;
-    padding: 1.5rem 0;
-  }
-
-  .os-phase::before {
-    content: '';
-    position: absolute;
-    left: -2.1rem;
-    top: 1.9rem;
-    width: 0.8rem;
-    height: 0.8rem;
-    border-radius: 9999px;
-    background: linear-gradient(120deg, var(--tur-amber), var(--tur-cyan));
-    box-shadow: 0 0 12px rgba(255, 145, 77, 0.5);
-  }
-
-  .os-phase-label {
-    display: inline-flex;
-    border-radius: 9999px;
-    border: 1px solid var(--tur-border-soft);
-    padding: 0.3rem 0.9rem;
-    font-size: 0.7rem;
-    letter-spacing: 0.3em;
-    text-transform: uppercase;
-    color: var(--tur-text-soft);
-  }
-
-  .ai-card,
-  .quote-card,
-  .pillar-card {
-    border-radius: 24px;
-    border: 1px solid var(--tur-border);
-    background: var(--tur-panel-alt);
-    padding: 1.5rem;
-  }
-
-  .ai-card {
-    box-shadow: 0 25px 70px rgba(2, 6, 23, 0.55);
-  }
-
-  .role-chip {
-    border-radius: 9999px;
-    border: 1px solid var(--tur-border-soft);
-    padding: 0.3rem 0.9rem;
-    font-size: 0.65rem;
-    letter-spacing: 0.3em;
-    text-transform: uppercase;
-    color: var(--tur-text-soft);
-  }
-
-  .about-section .rounded-3xl,
-  .about-section .rounded-2xl,
-  .about-section .grid.grid-cols-3 {
-    background: var(--tur-panel-alt);
-    border: 1px solid var(--tur-border);
-    color: var(--tur-text-muted);
-  }
-
-  .about-section .rounded-3xl h2,
-  .about-section .rounded-2xl h2,
-  .about-section .grid.grid-cols-3 p:first-child {
-    color: var(--tur-text-strong);
-  }
-
-  .contact-shell {
-    border-radius: 36px;
-    border: 1px solid var(--tur-border-strong);
-    background:
-      radial-gradient(
-        circle at 15% 20%,
-        rgba(255, 145, 77, 0.35),
-        transparent 55%
-      ),
-      radial-gradient(
-        circle at 80% 0%,
-        rgba(75, 225, 255, 0.25),
-        transparent 45%
-      ),
-      #04060f;
-    box-shadow: 0 45px 120px rgba(2, 6, 23, 0.7);
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    [data-reveal] {
-      opacity: 1;
-      transform: none;
-      transition: none;
-    }
-  }
-</style>

--- a/src/components/PostsList.astro
+++ b/src/components/PostsList.astro
@@ -14,25 +14,25 @@ const { posts } = Astro.props
 posts.sort(sortPosts)
 ---
 
-<ul class="space-y-6 p-0">
+<ul class="space-y-4 p-0">
   {
     posts.map(({ data, slug }) => (
-      <li class="group">
-        <article class="space-y-3 rounded-lg border border-slate-800 bg-slate-900/30 p-6 transition-all hover:border-slate-700 hover:bg-slate-900/50">
+      <li>
+        <article class="post-card group">
           <div class="flex flex-col justify-between gap-2 sm:flex-row sm:items-start">
             <div class="flex-1">
-              <h2 class="mb-2">
+              <h2 class="mb-1">
                 <a
-                  class="text-xl font-semibold text-slate-100 transition-colors hover:text-white sm:text-2xl"
+                  class="post-card-title"
                   href={`/posts/${slug}`}
                   data-astro-prefetch
                 >
                   {data.title}
                 </a>
               </h2>
-              <p class="text-slate-400">{data.description}</p>
+              <p class="post-card-desc">{data.description}</p>
             </div>
-            <time class="shrink-0 text-sm text-slate-500 sm:ml-4">
+            <time class="post-card-date shrink-0 sm:ml-4">
               {toDateString(data.publishedDate)}
             </time>
           </div>
@@ -42,3 +42,35 @@ posts.sort(sortPosts)
     ))
   }
 </ul>
+
+<style>
+  .post-card {
+    @apply rounded-2xl border p-5 transition-all duration-200;
+    border-color: rgba(255, 255, 255, 0.07);
+    background: #111114;
+  }
+
+  .post-card:hover {
+    border-color: rgba(255, 255, 255, 0.12);
+    transform: translateY(-1px);
+  }
+
+  .post-card-title {
+    @apply text-lg font-semibold transition-colors sm:text-xl;
+    color: #f0ebe3;
+  }
+
+  .post-card:hover .post-card-title {
+    @apply text-accent;
+  }
+
+  .post-card-desc {
+    @apply text-sm;
+    color: rgba(240, 235, 227, 0.55);
+  }
+
+  .post-card-date {
+    @apply text-xs;
+    color: rgba(240, 235, 227, 0.35);
+  }
+</style>

--- a/src/components/ProjectsList.astro
+++ b/src/components/ProjectsList.astro
@@ -30,7 +30,7 @@ const formatTimeline = (project: CollectionEntry<'projects'>) => {
 }
 ---
 
-<div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+<div class="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
   {
     projects.map((project) => {
       const { data } = project
@@ -40,54 +40,28 @@ const formatTimeline = (project: CollectionEntry<'projects'>) => {
       const hasLiveSite = Boolean(externalUrl && isAbsolute(externalUrl))
       const categoryTag =
         data.homepage?.tag ?? (data.tags.length > 0 ? data.tags[0] : null)
-      const cardClass =
-        'relative flex h-full min-h-[280px] flex-col overflow-hidden rounded-3xl border-2 border-white/[0.08] bg-gradient-to-br from-white/[0.08] via-white/[0.03] to-transparent p-6 shadow-2xl backdrop-blur-md sm:min-h-[320px] sm:p-8'
-      const interactiveClass = hasLiveSite
-        ? 'group block h-full transition-all duration-500 hover:[&>div]:border-accent/30'
-        : 'block h-full'
 
       const inner = (
-        <div
-          class:list={[
-            cardClass,
-            hasLiveSite &&
-              'transition-all duration-500 group-hover:shadow-[0_20px_60px_-15px_rgba(241,141,79,0.3)]'
-          ]}
-        >
-          <div
-            class={`absolute left-4 top-4 flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[10px] font-bold uppercase tracking-wider text-white shadow-md sm:left-6 sm:top-6 ${color}`}
-          >
+        <div class="project-card">
+          <div class={`project-status ${color}`}>
             <span
-              class={`h-1 w-1 rounded-full bg-white ${hasLiveSite && animate ? 'animate-pulse' : ''}`}
+              class={`h-1.5 w-1.5 rounded-full bg-white ${hasLiveSite && animate ? 'animate-pulse' : ''}`}
             />
             {label}
           </div>
-          <div class="flex flex-1 flex-col items-start justify-center pt-8 text-left sm:pt-0">
-            {categoryTag && (
-              <p class="mb-1 text-xs font-semibold uppercase tracking-[0.4em] text-white/50">
-                {categoryTag}
-              </p>
-            )}
-            <h3
-              class:list={[
-                'mb-2 text-2xl font-bold leading-tight tracking-tight text-white sm:mb-3 sm:text-3xl',
-                hasLiveSite &&
-                  'transition-colors duration-300 group-hover:text-accent'
-              ]}
-            >
-              {data.title}
-            </h3>
-            <p class="project-summary mb-3 text-sm text-white/80 sm:mb-4 sm:text-base">
-              {data.description}
-            </p>
-            <div class="flex flex-col gap-2 text-xs font-semibold text-white/60 sm:flex-row sm:items-center sm:text-sm">
-              <span class="inline-flex items-center gap-2 rounded-full border border-white/10 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-white/70 sm:px-3 sm:text-xs">
-                Timeline
-              </span>
+          <div class="project-card-body">
+            {categoryTag && <p class="section-eyebrow">{categoryTag}</p>}
+            <h3 class="project-card-title">{data.title}</h3>
+            <p class="project-card-desc">{data.description}</p>
+            <div class="project-card-meta">
+              <span class="project-card-meta-label">Timeline</span>
               <time>{timeline}</time>
             </div>
             {!hasLiveSite && (
-              <p class="mt-4 text-[10px] uppercase tracking-[0.25em] text-white/40">
+              <p
+                class="mt-3 text-xs uppercase tracking-wider"
+                style="color: rgba(240,235,227,0.3)"
+              >
                 No live site — status & direction only
               </p>
             )}
@@ -100,20 +74,59 @@ const formatTimeline = (project: CollectionEntry<'projects'>) => {
           href={externalUrl}
           target="_blank"
           rel="noopener noreferrer"
-          class={interactiveClass}
+          class="project-card-link group"
         >
           {inner}
         </a>
       ) : (
-        <div class={interactiveClass}>{inner}</div>
+        <div>{inner}</div>
       )
     })
   }
 </div>
 
 <style>
-  .project-summary {
-    color: rgba(248, 250, 252, 0.82);
-    line-height: 1.5;
+  .project-card {
+    @apply relative flex h-full min-h-[260px] flex-col overflow-hidden rounded-2xl border p-6 transition-all duration-300;
+    border-color: rgba(255, 255, 255, 0.07);
+    background: #111114;
+  }
+
+  .project-card-link:hover .project-card {
+    border-color: rgba(212, 160, 84, 0.3);
+    transform: translateY(-2px);
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.3);
+  }
+
+  .project-card-link:hover .project-card-title {
+    @apply text-accent;
+  }
+
+  .project-status {
+    @apply absolute left-4 top-4 flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider text-white;
+  }
+
+  .project-card-body {
+    @apply flex flex-1 flex-col justify-center pt-8;
+  }
+
+  .project-card-title {
+    @apply mb-2 text-xl font-bold leading-tight tracking-tight transition-colors sm:text-2xl;
+    color: #f0ebe3;
+  }
+
+  .project-card-desc {
+    @apply mb-3 text-sm leading-relaxed;
+    color: rgba(240, 235, 227, 0.65);
+  }
+
+  .project-card-meta {
+    @apply flex flex-col gap-1 text-xs font-medium;
+    color: rgba(240, 235, 227, 0.4);
+  }
+
+  .project-card-meta-label {
+    @apply inline-flex w-fit rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wider;
+    border-color: rgba(255, 255, 255, 0.08);
   }
 </style>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,30 +1,101 @@
 ---
 import FooterItem from '@/components/layout/FooterItem.astro'
-import Separator from '@/components/layout/Separator.astro'
 import config from '@/theme.config'
 
 const currentYear = new Date().getFullYear()
 ---
 
-<footer class="mt-auto">
-  <Separator />
-  <div
-    class="mx-auto flex w-full max-w-6xl flex-col items-center justify-between gap-4 px-3 py-4 text-2xl sm:flex-row sm:gap-2 sm:px-6 sm:py-8 lg:px-8"
-  >
-    <span class="text-base">&#169; {currentYear} {config.author}</span>
+<footer class="site-footer">
+  <div class="site-footer-inner">
+    <div class="site-footer-brand">
+      <a href="/" class="site-footer-logo">{config.title}</a>
+      <p class="site-footer-tagline">{config.description}</p>
+    </div>
 
-    <div class="flex gap-4">
+    <nav class="site-footer-nav" aria-label="Footer navigation">
+      <ul>
+        {
+          config.navbarItems.map((item) =>
+            'href' in item ? (
+              <li>
+                <a href={item.href}>{item.label}</a>
+              </li>
+            ) : null
+          )
+        }
+      </ul>
+    </nav>
+
+    <div class="site-footer-social">
       {config.footerItems.map((item) => <FooterItem {item} />)}
     </div>
   </div>
-  <div class="mx-auto max-w-6xl px-3 pb-6 text-center sm:px-6 lg:px-8">
+
+  <div class="site-footer-bottom">
+    <span>&#169; {currentYear} {config.author}</span>
     <a
       href="https://emilingemarkarlsson.com/"
       target="_blank"
       rel="noopener noreferrer"
-      class="text-xs text-slate-500 transition-colors hover:text-slate-400"
     >
       Built by emilingemarkarlsson
     </a>
   </div>
 </footer>
+
+<style>
+  .site-footer {
+    @apply mt-auto border-t;
+    border-color: rgba(255, 255, 255, 0.06);
+  }
+
+  .site-footer-inner {
+    @apply mx-auto grid w-full max-w-6xl gap-8 px-4 py-10 sm:px-6 sm:py-12 lg:grid-cols-[1.5fr_1fr_auto] lg:px-8;
+  }
+
+  .site-footer-logo {
+    @apply text-lg font-bold tracking-tight transition-colors;
+    color: #f0ebe3;
+  }
+
+  .site-footer-logo:hover {
+    @apply text-accent;
+  }
+
+  .site-footer-tagline {
+    @apply mt-2 max-w-sm text-sm leading-relaxed;
+    color: rgba(240, 235, 227, 0.45);
+  }
+
+  .site-footer-nav ul {
+    @apply flex flex-col gap-2;
+  }
+
+  .site-footer-nav a {
+    @apply text-sm transition-colors;
+    color: rgba(240, 235, 227, 0.6);
+  }
+
+  .site-footer-nav a:hover {
+    @apply text-accent;
+  }
+
+  .site-footer-social {
+    @apply flex gap-3;
+  }
+
+  .site-footer-bottom {
+    @apply mx-auto flex w-full max-w-6xl flex-col items-center justify-between gap-2 border-t px-4 py-4 text-xs sm:flex-row sm:px-6 lg:px-8;
+    border-color: rgba(255, 255, 255, 0.04);
+    color: rgba(240, 235, 227, 0.35);
+  }
+
+  .site-footer-bottom a {
+    @apply transition-colors;
+    color: rgba(240, 235, 227, 0.35);
+  }
+
+  .site-footer-bottom a:hover {
+    color: rgba(240, 235, 227, 0.6);
+  }
+</style>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -16,24 +16,18 @@ export const isNavItem = (item: HeaderItem): item is NavItemType =>
   Object.hasOwn(item, 'href')
 ---
 
-<header
-  class="sticky top-0 z-50 border-b border-gray-200/60 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:border-white/10 dark:bg-gray-950/60"
->
-  <div
-    class="mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-3 py-2 sm:px-6 sm:py-4 lg:px-8 lg:py-6"
-  >
-    <a
-      href="/"
-      class="flex gap-2 text-2xl font-bold text-accent sm:text-3xl lg:text-4xl"
-    >
-      <span class="xs:inline hidden">{config.title}</span>
-      <span class="xs:hidden">TUR</span>
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="/" class="site-logo">
+      <span class="site-logo-full">{config.title}</span>
+      <span class="site-logo-short">TUR</span>
     </a>
-    <nav class="hidden flex-col justify-end md:flex">
-      <ul class="flex gap-4 lg:gap-6">
+
+    <nav class="site-nav hidden md:flex" aria-label="Main navigation">
+      <ul class="site-nav-list">
         {
           config.navbarItems.map((item) => (
-            <li class="flex flex-col justify-center">
+            <li>
               {isNavItem(item) ? (
                 <NavItem
                   {item}
@@ -48,39 +42,36 @@ export const isNavItem = (item: HeaderItem): item is NavItemType =>
             </li>
           ))
         }
-        <li class="text-xl lg:text-2xl">
-          <a
-            href="/search"
-            class="flex items-center transition-colors hover:text-accent"
-          >
-            <span class="clickable iconify tabler--search"></span>
+        <li>
+          <a href="/search" class="site-nav-icon" aria-label="Search">
+            <span class="iconify tabler--search"></span>
           </a>
         </li>
-        <li class="text-xl lg:text-2xl">
-          {config.modeToggle && <ModeToggle />}
-        </li>
+        {
+          config.modeToggle && (
+            <li>
+              <ModeToggle />
+            </li>
+          )
+        }
       </ul>
     </nav>
-    <div class="flex items-center gap-3 text-xl sm:gap-4 sm:text-2xl md:hidden">
+
+    <div class="flex items-center gap-2 md:hidden">
       {config.modeToggle && <ModeToggle />}
-      <a
-        href="/search"
-        class="flex items-center transition-colors hover:text-accent"
-      >
-        <span class="clickable iconify tabler--search"></span>
+      <a href="/search" class="site-nav-icon" aria-label="Search">
+        <span class="iconify tabler--search"></span>
       </a>
       <MobileNavToggle />
     </div>
   </div>
-  <div
-    id="mobile-nav"
-    class="mx-auto hidden w-full max-w-6xl border-t border-gray-200/60 px-3 pt-4 sm:px-6 dark:border-white/10"
-  >
-    <nav class="flex flex-col justify-end pb-4">
-      <ul class="flex flex-col items-center gap-2">
+
+  <div id="mobile-nav" class="site-mobile-nav hidden">
+    <nav aria-label="Mobile navigation">
+      <ul class="site-mobile-nav-list">
         {
           config.navbarItems.map((item) => (
-            <li class="flex flex-col justify-center">
+            <li>
               {isNavItem(item) ? (
                 <NavItem
                   {item}
@@ -99,3 +90,54 @@ export const isNavItem = (item: HeaderItem): item is NavItemType =>
     </nav>
   </div>
 </header>
+
+<style>
+  .site-header {
+    @apply sticky top-0 z-50 border-b backdrop-blur-md;
+    border-color: rgba(255, 255, 255, 0.06);
+    background: rgba(8, 8, 10, 0.85);
+  }
+
+  .site-header-inner {
+    @apply mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-4 py-3 sm:px-6 sm:py-4 lg:px-8;
+  }
+
+  .site-logo {
+    @apply text-lg font-bold tracking-tight transition-colors sm:text-xl;
+    color: var(--roads-text, #f0ebe3);
+  }
+
+  .site-logo:hover {
+    @apply text-accent;
+  }
+
+  .site-logo-short {
+    @apply sm:hidden;
+  }
+
+  .site-logo-full {
+    @apply hidden sm:inline;
+  }
+
+  .site-nav-list {
+    @apply flex items-center gap-1 lg:gap-2;
+  }
+
+  .site-nav-icon {
+    @apply flex items-center justify-center rounded-lg p-2 text-lg transition-colors;
+    color: rgba(240, 235, 227, 0.6);
+  }
+
+  .site-nav-icon:hover {
+    @apply text-accent;
+  }
+
+  .site-mobile-nav {
+    @apply border-t px-4 pb-4 pt-3 sm:px-6;
+    border-color: rgba(255, 255, 255, 0.06);
+  }
+
+  .site-mobile-nav-list {
+    @apply flex flex-col items-center gap-1;
+  }
+</style>

--- a/src/components/layout/NavItem.astro
+++ b/src/components/layout/NavItem.astro
@@ -15,13 +15,24 @@ const {
 
 <a
   href={href}
-  class={`flex items-center gap-1 whitespace-nowrap ${
-    isActive ? 'text-accent/100' : 'clickable'
-  }`}
+  class:list={['site-nav-link', { 'is-active': isActive }]}
   target={isAbsolute(href) ? '_blank' : '_self'}
 >
-  {icon && <span class={`iconify text-xl ${icon}`} />}
-  <span class={isActive ? `underline` : ''}>
-    {label}
-  </span>
+  {icon && <span class={`iconify text-base ${icon}`} />}
+  <span>{label}</span>
 </a>
+
+<style>
+  .site-nav-link {
+    @apply flex items-center gap-1.5 whitespace-nowrap rounded-lg px-3 py-2 text-sm font-medium transition-colors;
+    color: rgba(240, 235, 227, 0.6);
+  }
+
+  .site-nav-link:hover {
+    color: #f0ebe3;
+  }
+
+  .site-nav-link.is-active {
+    @apply text-accent;
+  }
+</style>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -23,28 +23,18 @@ const frontmatter: PageLayoutProps['frontmatter'] = {
     <section class="section-shell space-y-4 text-center">
       <p class="section-eyebrow">Experiments in flight</p>
       <div class="space-y-6">
-        <h1 class="text-4xl font-semibold text-white sm:text-5xl">
+        <h1 class="section-title text-4xl sm:text-5xl">
           Where we test impossible playbooks
         </h1>
-        <p class="mx-auto max-w-3xl text-base text-slate-300 sm:text-lg">
+        <p class="section-lead mx-auto max-w-3xl">
           Every project is a validation contract inside Company OS — Focus,
           Monitor or Parked. Live product links only when a site exists;
           otherwise status and direction live here.
         </p>
       </div>
-      <div class="flex flex-col gap-3 pt-2 sm:flex-row sm:justify-center">
-        <a
-          href="/contact"
-          class="inline-flex items-center justify-center gap-2 rounded-2xl bg-white px-6 py-3 font-semibold text-gray-900"
-        >
-          Propose a build
-        </a>
-        <a
-          href="/tools"
-          class="inline-flex items-center justify-center gap-2 rounded-2xl border border-white/40 px-6 py-3 font-semibold text-white"
-        >
-          Inspect the stack
-        </a>
+      <div class="hero-ctas justify-center pt-2">
+        <a href="/contact" class="btn-primary">Propose a build</a>
+        <a href="/tools" class="btn-secondary">Inspect the stack</a>
       </div>
     </section>
 
@@ -54,10 +44,10 @@ const frontmatter: PageLayoutProps['frontmatter'] = {
       >
         <div>
           <p class="section-eyebrow">Active portfolio</p>
-          <h2 class="text-3xl font-semibold text-white">
+          <h2 class="section-title">
             {projectCount} builds across research, product, and GTM
           </h2>
-          <p class="mt-2 max-w-2xl text-slate-300">
+          <p class="section-lead mt-2">
             From stealth operating systems to public-facing SaaS launches, each
             project runs on the same automation-first discipline.
           </p>

--- a/src/style/color-schemes.css
+++ b/src/style/color-schemes.css
@@ -1,4 +1,14 @@
 @layer base {
+  .scheme-roads {
+    --accent: 212, 160, 84;
+    --accent-bg: 8, 8, 10;
+
+    &[data-mode='dark'] {
+      --accent: 212, 160, 84;
+      --accent-bg: 8, 8, 10;
+    }
+  }
+
   .scheme-mono {
     --accent: 0, 0, 0;
     --accent-bg: 255, 255, 255;

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -1,5 +1,6 @@
 @import 'color-schemes.css';
 @import 'astro-code.css';
+@import 'site.css';
 
 @tailwind base;
 @tailwind components;
@@ -7,7 +8,7 @@
 
 @layer base {
   :root {
-    @apply bg-accent-bg selection:bg-accent/75 overflow-y-scroll scroll-smooth underline-offset-4 selection:text-white selection:dark:text-black;
+    @apply bg-accent-bg selection:bg-accent/75 overflow-y-scroll scroll-smooth underline-offset-4 selection:text-white;
 
     #page-wrapper {
       @apply flex min-h-[100svh] w-full flex-col justify-between;

--- a/src/style/site.css
+++ b/src/style/site.css
@@ -1,0 +1,286 @@
+/* ── The Unnamed Roads — shared site design system ── */
+
+@layer components {
+  .homepage-shell {
+    --roads-bg: #08080a;
+    --roads-surface: #111114;
+    --roads-surface-elevated: #18181c;
+    --roads-border: rgba(255, 255, 255, 0.07);
+    --roads-border-hover: rgba(255, 255, 255, 0.14);
+    --roads-text: #f0ebe3;
+    --roads-text-muted: rgba(240, 235, 227, 0.65);
+    --roads-text-soft: rgba(240, 235, 227, 0.4);
+    --roads-accent: #d4a054;
+    --roads-accent-soft: rgba(212, 160, 84, 0.12);
+    --roads-accent-glow: rgba(212, 160, 84, 0.25);
+
+    /* Legacy aliases for ToolStackSection */
+    --tur-base: var(--roads-bg);
+    --tur-panel: var(--roads-surface);
+    --tur-border: var(--roads-border);
+    --tur-text-strong: var(--roads-text);
+    --tur-text-muted: var(--roads-text-muted);
+    --tur-text-soft: var(--roads-text-soft);
+    --tur-amber: var(--roads-accent);
+
+    color: var(--roads-text-muted);
+  }
+
+  /* ── Section primitives ── */
+
+  .section-eyebrow {
+    @apply text-xs font-medium uppercase tracking-[0.35em] text-accent/80;
+  }
+
+  .section-shell {
+    @apply rounded-2xl border p-6 sm:p-8 lg:p-10;
+    border-color: var(--roads-border);
+    background: var(--roads-surface);
+  }
+
+  .section-title {
+    @apply text-2xl font-semibold tracking-tight sm:text-3xl;
+    color: var(--roads-text);
+  }
+
+  .section-lead {
+    @apply max-w-2xl text-base leading-relaxed;
+    color: var(--roads-text-muted);
+  }
+
+  /* ── Hero ── */
+
+  .hero {
+    @apply relative overflow-hidden rounded-3xl px-6 py-14 sm:px-10 sm:py-20 lg:px-14 lg:py-24;
+    background:
+      radial-gradient(ellipse 70% 60% at 50% -10%, var(--roads-accent-soft), transparent 60%),
+      var(--roads-surface-elevated);
+    border: 1px solid var(--roads-border);
+  }
+
+  .hero-headline {
+    @apply text-4xl font-bold leading-[1.1] tracking-tight sm:text-5xl lg:text-6xl;
+    color: var(--roads-text);
+  }
+
+  .hero-lead {
+    @apply mt-4 max-w-xl text-base leading-relaxed sm:text-lg;
+    color: var(--roads-text-muted);
+  }
+
+  .hero-lead strong {
+    color: var(--roads-accent);
+    font-weight: 600;
+  }
+
+  .hero-ctas {
+    @apply mt-8 flex flex-wrap gap-3;
+  }
+
+  .btn-primary {
+    @apply inline-flex items-center justify-center gap-2 rounded-full px-6 py-3 text-sm font-semibold transition-all duration-200;
+    background: var(--roads-accent);
+    color: var(--roads-bg);
+  }
+
+  .btn-primary:hover {
+    box-shadow: 0 8px 32px var(--roads-accent-glow);
+    transform: translateY(-1px);
+  }
+
+  .btn-secondary {
+    @apply inline-flex items-center justify-center gap-2 rounded-full border px-6 py-3 text-sm font-semibold transition-all duration-200;
+    border-color: var(--roads-border-hover);
+    color: var(--roads-text);
+  }
+
+  .btn-secondary:hover {
+    border-color: var(--roads-accent);
+    color: var(--roads-accent);
+  }
+
+  /* ── Control loop (simplified) ── */
+
+  .loop-panel {
+    @apply mt-10 rounded-2xl border p-5 sm:p-6;
+    border-color: var(--roads-border);
+    background: rgba(0, 0, 0, 0.25);
+  }
+
+  .loop-header {
+    @apply mb-4 flex flex-wrap items-center justify-between gap-2;
+  }
+
+  .loop-label {
+    @apply text-xs font-medium uppercase tracking-[0.3em];
+    color: var(--roads-text-soft);
+  }
+
+  .loop-live {
+    @apply inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-emerald-400;
+  }
+
+  .loop-live-dot {
+    @apply h-1.5 w-1.5 rounded-full bg-emerald-400;
+    box-shadow: 0 0 8px rgba(52, 211, 153, 0.7);
+    animation: loop-pulse 2s ease-in-out infinite;
+  }
+
+  @keyframes loop-pulse {
+    50% { opacity: 0.5; }
+  }
+
+  .loop-steps {
+    @apply flex flex-wrap items-stretch gap-2;
+  }
+
+  .loop-step {
+    @apply flex-1 rounded-xl border p-3 text-center;
+    border-color: var(--roads-border);
+    background: rgba(255, 255, 255, 0.03);
+    min-width: 5rem;
+  }
+
+  .loop-step-label {
+    @apply text-xs font-semibold uppercase tracking-wide;
+    color: var(--roads-accent);
+  }
+
+  .loop-step-detail {
+    @apply mt-1 text-xs leading-snug;
+    color: var(--roads-text-soft);
+  }
+
+  .loop-gate {
+    @apply mt-4 flex flex-wrap items-center gap-2 rounded-xl border px-4 py-2.5;
+    border-color: rgba(212, 160, 84, 0.25);
+    background: var(--roads-accent-soft);
+  }
+
+  .loop-gate-pill {
+    @apply rounded-full px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wider;
+    background: var(--roads-accent);
+    color: var(--roads-bg);
+  }
+
+  .loop-gate-detail {
+    @apply text-xs;
+    color: var(--roads-text-muted);
+  }
+
+  /* ── Cards ── */
+
+  .venture-card {
+    @apply relative rounded-2xl border p-6 transition-all duration-300;
+    border-color: var(--roads-border);
+    background: var(--roads-surface);
+  }
+
+  .venture-card:hover {
+    border-color: var(--roads-border-hover);
+    transform: translateY(-2px);
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.3);
+  }
+
+  .signal-card {
+    @apply rounded-2xl border p-5;
+    border-color: var(--roads-border);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .signal-tag {
+    @apply rounded-full border px-3 py-1 text-xs font-medium;
+    border-color: var(--roads-border);
+    color: var(--roads-text-muted);
+  }
+
+  .filter-chip {
+    @apply rounded-full border px-3 py-1 text-xs font-medium;
+    border-color: var(--roads-border);
+    color: var(--roads-text-soft);
+  }
+
+  .status-pill {
+    @apply inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold;
+  }
+
+  .status-dot {
+    @apply h-1.5 w-1.5 rounded-full;
+  }
+
+  .quote-card {
+    @apply rounded-2xl border p-6;
+    border-color: var(--roads-border);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  /* ── Timeline ── */
+
+  .os-timeline {
+    @apply list-none space-y-0 p-0;
+  }
+
+  .os-phase {
+    @apply relative grid gap-4 border-l-2 py-6 pl-8;
+    border-color: var(--roads-border);
+  }
+
+  .os-phase:last-child {
+    @apply pb-0;
+  }
+
+  .os-phase::before {
+    content: '';
+    @apply absolute -left-[5px] top-8 h-2 w-2 rounded-full;
+    background: var(--roads-accent);
+    box-shadow: 0 0 12px var(--roads-accent-glow);
+  }
+
+  .os-phase-label {
+    @apply text-xs font-semibold uppercase tracking-[0.3em];
+    color: var(--roads-accent);
+  }
+
+  /* ── Contact CTA ── */
+
+  .contact-shell {
+    @apply relative overflow-hidden rounded-3xl border p-10 text-center sm:p-14;
+    border-color: var(--roads-border);
+    background:
+      radial-gradient(ellipse 60% 80% at 50% 120%, var(--roads-accent-soft), transparent),
+      var(--roads-surface-elevated);
+  }
+
+  /* ── Reveal animations ── */
+
+  :where(:root:not(.reveal-enabled)) [data-reveal] {
+    opacity: 1;
+    transform: none;
+  }
+
+  .reveal-enabled [data-reveal] {
+    opacity: 0;
+    transform: translateY(24px);
+    transition:
+      opacity 0.7s ease,
+      transform 0.7s ease;
+    transition-delay: var(--reveal-delay, 0ms);
+  }
+
+  [data-reveal].is-visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .loop-live-dot {
+      animation: none;
+    }
+
+    .reveal-enabled [data-reveal] {
+      opacity: 1;
+      transform: none;
+      transition: none;
+    }
+  }
+}

--- a/src/theme.config.ts
+++ b/src/theme.config.ts
@@ -4,7 +4,7 @@ export default defineThemeConfig({
   site: 'https://www.theunnamedroads.com',
   title: 'The Unnamed Road',
   description:
-    'AI-native venture studio building the future roads of business. Where human creativity merges with artificial intelligence to forge impossible innovations through anonymous, experimental methodology and post-human entrepreneurship.',
+    'AI-native venture studio building measured, decision-first companies. Portfolio of focused experiments, Field Notes for indie founders, and a Company OS that compounds learning.',
   author: 'The Unnamed Road',
   navbarItems: [
     { label: 'Home', href: '/' },
@@ -31,7 +31,7 @@ export default defineThemeConfig({
   locale: 'en',
   mode: 'dark',
   modeToggle: false,
-  colorScheme: 'scheme-mono',
+  colorScheme: 'scheme-roads',
   openGraphImage: undefined,
   postsPerPage: 4,
   projectsPerPage: 3,

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface Agent {
 const Modes = ['dark', 'light'] as const
 
 export const ColorSchemes = [
+  'scheme-roads',
   'scheme-mono',
   'scheme-nord',
   'scheme-aurora',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Summarize the proposed changes**

Full UI/UX redesign of The Unnamed Roads with a unified editorial design system. Replaces the heavy glassmorphic homepage (1800+ lines of scoped CSS) with a clean, warm dark theme built on shared design tokens.

Key changes:
- New `scheme-roads` color palette: warm dark background (#08080a) with amber accent (#d4a054)
- Shared design system in `src/style/site.css` — section shells, cards, buttons, timeline, reveal animations
- Simplified hero: readable headline + control loop step panel (removed browser-chrome UI)
- Redesigned header (minimal sticky nav), footer (brand + nav links + social)
- Updated project cards, post list, and announcement bar to match
- Net reduction of ~800 lines of CSS while improving consistency across pages

**What is the type of change? Select one or more.**
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Other

**Is there any action needed after merging?**
No — deploys automatically via Vercel on merge to `main`.

**Please make sure the PR complies with this checklist**
- [x] The change has been tested locally
- [x] The code has been linted and type-checked (`pnpm check` passes)
- [x] Build succeeds (`pnpm build`)
- [x] There is currently no merge conflict
- [x] No new warnings or errors

**Additional context**

Design goals: beautiful, simple, stands out, easy to SEO/AEO optimize. Semantic HTML structure preserved; JSON-LD and meta tags untouched in `BaseLayout.astro`. Content-driven sections still read from `structure.json`.

[Homepage hero — new clean design](https://cursor.com/agents/bc-f3479bf2-3e7f-412d-a151-c1b0dd05aa2a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhomepage-hero.png)
[Projects page — updated cards](https://cursor.com/agents/bc-f3479bf2-3e7f-412d-a151-c1b0dd05aa2a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fprojects.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3479bf2-3e7f-412d-a151-c1b0dd05aa2a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3479bf2-3e7f-412d-a151-c1b0dd05aa2a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

