### PR TITLE
fix: route agent PRs to human approval inbox

### DIFF
--- a/.github/workflows/agent-pr-inbox.yml
+++ b/.github/workflows/agent-pr-inbox.yml
@@ -1,0 +1,54 @@
+name: Agent PR inbox
+
+# Cursor Cloud Agent tokens cannot assign PRs (403). This workflow ensures
+# agent PRs always land in Emil's GitHub approval queues.
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+
+jobs:
+  route-to-human:
+    if: startsWith(github.head_ref, 'cursor/agent-issue-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign and request review from emilingemarkarlsson
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = context.payload.pull_request.number;
+            const human = 'emilingemarkarlsson';
+
+            await github.rest.issues.addAssignees({
+              owner,
+              repo,
+              issue_number: pull_number,
+              assignees: [human],
+            });
+            core.info(`Assigned PR #${pull_number} to ${human}`);
+
+            try {
+              await github.rest.pulls.requestReviewers({
+                owner,
+                repo,
+                pull_number,
+                reviewers: [human],
+              });
+              core.info(`Requested review on PR #${pull_number} from ${human}`);
+            } catch (error) {
+              // Author cannot request review from self — inbox assignee is enough.
+              if (error.status === 422) {
+                core.warning(`Could not request review (likely self-review): ${error.message}`);
+              } else {
+                throw error;
+              }
+            }

--- a/docs/agent-setup/APPROVE.md
+++ b/docs/agent-setup/APPROVE.md
@@ -27,7 +27,13 @@ Execute ska alltid **assigna** dig också. Använd den här om review-request sa
 
 ### Om båda köerna är tomma
 
-Inget att göra just nu.
+Tre vanliga orsaker:
+
+1. **Ingen öppen agent-PR** — Execute har inte kört, eller inget issue har `agent:ready`.
+2. **PR redan mergad** — mergade PR:er försvinner från båda köerna. Smoke test [#12](https://github.com/emilingemarkarlsson/theunnamedroads/pull/12) mergades t.ex. direkt; då är det *klart*, inte trasigt.
+3. **Fel kö** — agent-PR:er hamnar i [Review requests](https://github.com/pulls/review-requested) först. [Assigned](https://github.com/pulls/assigned) är backup om Cursor-boten inte kunde assigna (GitHub Action `agent-pr-inbox.yml` fixar det framåt).
+
+Manuellt filter om något glipade: [öppna `cursor/agent-issue-*` PR:er](https://github.com/emilingemarkarlsson/theunnamedroads/pulls?q=is%3Apr+is%3Aopen+head%3Acursor%2Fagent-issue-).
 
 ### Relaterat
 

--- a/docs/agent-setup/GO_LIVE.md
+++ b/docs/agent-setup/GO_LIVE.md
@@ -1,0 +1,58 @@
+# Go-live checklist (manual clicks this agent cannot do)
+
+Cloud Agent tokens are **read-only** on GitHub for labels/issues/merge, and Cursor Automations have **no create API** from this environment.
+
+## Status
+
+- [x] Agent loop scaffold merged ([#10](https://github.com/emilingemarkarlsson/theunnamedroads/pull/10))
+- [x] Agent labels bootstrapped (`agent:draft|ready|running|done|needs-human`, `learn:candidate`)
+- [x] Execute automation configured (cron `*/30` + `agent:ready`)
+- [x] Smoke test ([#11](https://github.com/emilingemarkarlsson/theunnamedroads/issues/11) → [#12](https://github.com/emilingemarkarlsson/theunnamedroads/pull/12)) — Execute picked up `agent:ready` and opened a PR
+- [ ] **Agent PR inbox workflow** merged — auto-assign + review request on `cursor/agent-issue-*` PRs (fixes empty Assigned queue)
+
+Re-run label bootstrap if needed: push to `main` (workflow `.github/workflows/sync-agent-labels.yml`) or **Actions → Sync agent labels → Run workflow**.
+
+## Create Execute automation
+
+1. Open https://cursor.com/automations → **New**
+2. Repo: `emilingemarkarlsson/theunnamedroads`
+3. Trigger: Issue labeled `agent:ready` (or cron `*/30 * * * *`)
+4. Paste prompt from [EXECUTE_PROMPT.md](./EXECUTE_PROMPT.md)
+5. Tools: GitHub, Open PR, Request Reviewers, Comment — **Don't Allow PR Approval**
+6. Save / enable
+
+## Dashboard sanity
+
+- [ ] GitHub integration has repo access
+- [ ] Environment linked (`.cursor/environment.json`)
+- [ ] MCP GitHub (+ Vercel optional)
+
+## First smoke test
+
+1. **New issue** → template **Agent Task**
+2. Fill Mål + Acceptanskriterier (include CI grön)
+3. Replace `agent:draft` with `agent:ready`
+4. Wait for automation → PR should appear
+5. PR ska synas under [Review requests](https://github.com/pulls/review-requested) **och** [Assigned](https://github.com/pulls/assigned)
+6. Godkänn enligt [APPROVE.md](./APPROVE.md) — **merga inte förrän du läst diffen**
+
+### Om kön är tom efter smoke test
+
+Smoke test-PR [#12](https://github.com/emilingemarkarlsson/theunnamedroads/pull/12) **mergades redan** — därför syns inget att godkänna. Det betyder att loopen fungerade, inte att den är trasig. Skapa en ny `agent:ready`-issue för nästa test.
+
+## After changing Execute prompt
+
+1. Open your Execute automation in https://cursor.com/automations
+2. Replace the prompt with the full block from [EXECUTE_PROMPT.md](./EXECUTE_PROMPT.md)
+3. Save
+
+## Create Learn automation (mål 2)
+
+1. Open https://cursor.com/automations → **New**
+2. Name: `Learn from agent runs`
+3. Repo: same
+4. Trigger: cron `0 */6 * * *` (or manual)
+5. Paste prompt from [LEARN_PROMPT.md](./LEARN_PROMPT.md)
+6. Save / enable
+
+ROI-nivå: håll **mänsklig merge**. Full auto-merge är inte målet — matad kö + learn-PR:er är.

--- a/docs/agent-setup/PORTABLE_PLAYBOOK.md
+++ b/docs/agent-setup/PORTABLE_PLAYBOOK.md
@@ -32,7 +32,8 @@ Without `agent:ready` issues, Execute should no-op.
 | Build | `pnpm build` (when acceptance requires it) |
 | Deploy | `git push origin main` → Vercel (`tur-site`) |
 | Default branch | `main` |
-| Human inbox | https://github.com/pulls/assigned |
+| Human inbox | https://github.com/pulls/review-requested (primär), https://github.com/pulls/assigned (backup) |
+| Agent PR routing | `.github/workflows/agent-pr-inbox.yml` — auto-assign + review on `cursor/agent-issue-*` |
 
 See also `AGENTS.md` for content and hosting rules.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Smoke test PR #12 worked (Execute opened a PR and it was merged), but Emil saw **nothing to approve** in GitHub — unlike the `emilingemarkarlsson-astro-theme` flow.

Root causes:
1. **PR #12 was already merged** (~1 min after creation) — empty queue is expected after merge, not a broken loop.
2. **Cursor bot cannot assign PRs** (GitHub 403) — only review was requested, so `/pulls/assigned` stayed empty.
3. User may have checked Assigned instead of Review requests.

## Fix

- Add `.github/workflows/agent-pr-inbox.yml` — on `cursor/agent-issue-*` PRs: assign + request review from `emilingemarkarlsson`.
- Update `APPROVE.md` with empty-queue troubleshooting.
- Add `GO_LIVE.md` checklist (mirrors astro-theme project).

## After merge

1. Create a new Agent Task issue → flip to `agent:ready`
2. Wait for Execute (≤30 min) or Run now
3. PR should appear in **both** [Review requests](https://github.com/pulls/review-requested) and [Assigned](https://github.com/pulls/assigned)
4. Approve + merge manually (don't merge until you've read the diff)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3479bf2-3e7f-412d-a151-c1b0dd05aa2a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3479bf2-3e7f-412d-a151-c1b0dd05aa2a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

