### PR TITLE
feat(seo): AEO surfaces — FAQ, Person, nav, sitemap, IndexNow

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -7,9 +7,18 @@ import codeHeadersPlugin from './src/plugins/codeHeadersPlugin'
 import readingTimePlugin from './src/plugins/readingTimePlugin'
 import config from './src/theme.config'
 
+const SITEMAP_EXCLUDE = [
+  /^\/tags(\/|$)/,
+  /^\/posts\/\d+\/?$/,
+  /^\/services(\/|$)/,
+  /emil-ingemark-karlsson/,
+  /^\/authors\//
+]
+
 export default defineConfig({
   site: config.site,
   redirects: {
+    '/sitemap.xml': '/sitemap-index.xml',
     '/services/ai-native-venture-studio': '/',
     '/projects/emil-ingemark-karlsson': {
       status: 301,
@@ -21,7 +30,16 @@ export default defineConfig({
       destination: '/authors/Emil Ingemar Karlsson'
     }
   },
-  integrations: [tailwind(), mdx(), sitemap()],
+  integrations: [
+    tailwind(),
+    mdx(),
+    sitemap({
+      filter: (page) => {
+        const path = page.replace(config.site, '').replace(/\/$/, '') || '/'
+        return !SITEMAP_EXCLUDE.some((pattern) => pattern.test(path))
+      }
+    })
+  ],
   markdown: {
     shikiConfig: {
       themes: config.shikiThemes,

--- a/scripts/indexnow.js
+++ b/scripts/indexnow.js
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 
 const CONFIG = {
-  host: 'theunnamedroads.com',
+  host: 'www.theunnamedroads.com',
   key: '741e73bc05ca4ca8b93944e7e9231f99',
   sitemapPath: path.join(process.cwd(), 'dist', 'sitemap-0.xml'), // Astro usually names it sitemap-0.xml
   indexNowApi: 'https://api.indexnow.org/indexnow'

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -3,6 +3,10 @@ import FooterItem from '@/components/layout/FooterItem.astro'
 import config from '@/theme.config'
 
 const currentYear = new Date().getFullYear()
+const footerLinks = [
+  ...config.navbarItems,
+  ...(config.footerNavItems ?? [])
+].filter((item): item is { label: string; href: string } => 'href' in item)
 ---
 
 <footer class="site-footer">
@@ -15,13 +19,11 @@ const currentYear = new Date().getFullYear()
     <nav class="site-footer-nav" aria-label="Footer navigation">
       <ul>
         {
-          config.navbarItems.map((item) =>
-            'href' in item ? (
-              <li>
-                <a href={item.href}>{item.label}</a>
-              </li>
-            ) : null
-          )
+          footerLinks.map((item) => (
+            <li>
+              <a href={item.href}>{item.label}</a>
+            </li>
+          ))
         }
       </ul>
     </nav>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -102,6 +102,7 @@ const organizationJsonLd = {
   url: config.site,
   logo: `${config.site}/favicon-tur.svg`,
   sameAs: sameAsProfiles,
+  founder: { '@id': `${config.site}#founder` },
   contactPoint: [
     {
       '@type': 'ContactPoint',
@@ -129,7 +130,23 @@ const websiteJsonLd = {
 }
 
 const pathname = Astro.url.pathname
+const isHomePage = pathname === '/' || pathname === ''
 const isAgentsPage = pathname === '/agents' || pathname === '/agents/'
+
+const founderPersonJsonLd = isHomePage
+  ? {
+      '@type': 'Person',
+      '@id': `${config.site}#founder`,
+      name: 'Emil Ingemar Karlsson',
+      jobTitle: 'Operator',
+      worksFor: { '@id': organizationId },
+      homeLocation: {
+        '@type': 'Place',
+        name: 'Stockholm, Sweden'
+      },
+      url: 'https://emilingemarkarlsson.com/'
+    }
+  : null
 
 const webPageDateModified = dateModifiedValue?.toISOString() ?? publishedDateValue?.toISOString() ?? new Date().toISOString()
 
@@ -219,6 +236,7 @@ const jsonLdGraph: Record<string, unknown>[] = [
   webPageJsonLd,
   breadcrumbJsonLd
 ]
+if (founderPersonJsonLd) jsonLdGraph.push(founderPersonJsonLd)
 if (articleJsonLd) jsonLdGraph.push(articleJsonLd)
 if (faqJsonLd) jsonLdGraph.push(faqJsonLd)
 

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -31,7 +31,7 @@ const wordCount = post.body.split(/\s+/).filter(Boolean).length
 const frontmatter: PageLayoutProps['frontmatter'] = {
   ...post.data,
   openGraphImage: post.data.openGraphImage || `/posts/${post.slug}.png`,
-  activeHeaderLink: 'Blog',
+  activeHeaderLink: 'Field Notes',
   scrollProgress: true,
   searchable: true,
   publishedDate: post.data.publishedDate,

--- a/src/pages/authors/[author].astro
+++ b/src/pages/authors/[author].astro
@@ -28,7 +28,7 @@ const frontmatter: PageLayoutProps['frontmatter'] = {
   description: agent
     ? `${agent.role} at The Unnamed Roads. ${agent.bio}`
     : `Articles by ${author}`,
-  activeHeaderLink: 'Blog'
+  activeHeaderLink: 'Field Notes'
 }
 ---
 

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -4,8 +4,33 @@ title: The Unnamed Roads — AI Venture Studio Running 10+ Projects on Self-Host
 description: "One founder. 10+ live projects. AI agents draft and research inside policy; humans Approve before publish, deploy, or external send. Self-hosted on Hetzner + Coolify for ~400 kr/month."
 activeHeaderLink: Home
 fullBleed: true
+faq:
+  - question: "What is The Unnamed Roads?"
+    answer: "A one-operator AI-native venture studio in Stockholm. We run a bounded Focus set with measured experiments, human Approve gates, and open Field Notes — not a consulting hire funnel."
+  - question: "What does Focus mean in the portfolio?"
+    answer: "Focus projects have an active validation contract and daily growth attention — currently three product bets. Everything else is Monitor, Parked or Avvecklat. See the Focus · Monitor · Parked policy page."
+  - question: "Do agents publish or send outbound autonomously?"
+    answer: "No. Agents draft and research inside policy. Publish, deploy and external send require explicit human Approve — typically on phone, not in meetings."
 ---
 
 import HomepageShell from '@/components/HomepageShell.astro'
 
 <HomepageShell />
+
+<section class="section-shell mx-auto max-w-3xl space-y-6 pb-16" aria-labelledby="home-faq">
+  <h2 id="home-faq" class="text-2xl font-semibold text-white">Common questions</h2>
+  <dl class="space-y-5">
+    <div>
+      <dt class="font-semibold text-white">What is The Unnamed Roads?</dt>
+      <dd class="mt-1 text-slate-300">A one-operator AI-native venture studio in Stockholm. We run a bounded Focus set with measured experiments, human Approve gates, and open Field Notes — not a consulting hire funnel.</dd>
+    </div>
+    <div>
+      <dt class="font-semibold text-white">What does Focus mean in the portfolio?</dt>
+      <dd class="mt-1 text-slate-300">Focus projects have an active validation contract and daily growth attention — currently three product bets. Everything else is Monitor, Parked or Avvecklat. See <a class="text-accent underline" href="/insights/focus-monitor-parked">Focus · Monitor · Parked</a>.</dd>
+    </div>
+    <div>
+      <dt class="font-semibold text-white">Do agents publish or send outbound autonomously?</dt>
+      <dd class="mt-1 text-slate-300">No. Agents draft and research inside policy. Publish, deploy and external send require explicit human Approve — typically on phone, not in meetings.</dd>
+    </div>
+  </dl>
+</section>

--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -19,11 +19,13 @@ type Props = InferGetStaticPropsType<typeof getStaticPaths>
 const { page } = Astro.props
 
 const pageTitle =
-  page.currentPage === 1 ? 'Posts' : `Posts - Page ${page.currentPage}`
+  page.currentPage === 1
+    ? 'Field Notes'
+    : `Field Notes — Page ${page.currentPage}`
 
 const frontmatter: PageLayoutProps['frontmatter'] = {
   title: pageTitle,
-  activeHeaderLink: 'Blog',
+  activeHeaderLink: 'Field Notes',
   prev: page.url.prev,
   next: page.url.next
 }

--- a/src/pages/posts/[page].astro
+++ b/src/pages/posts/[page].astro
@@ -18,11 +18,11 @@ type Props = InferGetStaticPropsType<typeof getStaticPaths>
 
 const { page } = Astro.props
 
-const pageTitle = `Posts - Page ${page.currentPage}`
+const pageTitle = `Field Notes — Page ${page.currentPage}`
 
 const frontmatter: PageLayoutProps['frontmatter'] = {
   title: pageTitle,
-  activeHeaderLink: 'Blog'
+  activeHeaderLink: 'Field Notes'
 }
 ---
 

--- a/src/theme.config.ts
+++ b/src/theme.config.ts
@@ -7,12 +7,16 @@ export default defineThemeConfig({
     'AI-native venture studio building measured, decision-first companies. Portfolio of focused experiments, Field Notes for indie founders, and a Company OS that compounds learning.',
   author: 'The Unnamed Roads',
   navbarItems: [
-    { label: 'Home', href: '/' },
+    { label: 'Projects', href: '/projects' },
+    { label: 'Field Notes', href: '/posts' },
     { label: 'About', href: '/about' },
+    { label: 'Insights', href: '/insights' }
+  ],
+  footerNavItems: [
     { label: 'Stack', href: '/stack' },
     { label: 'Tools', href: '/tools' },
-    { label: 'Insights', href: '/insights' },
-    { label: 'Contact', href: '/contact' }
+    { label: 'Contact', href: '/contact' },
+    { label: 'For assistants', href: '/for-assistants' }
   ],
   footerItems: [
     {

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export interface ThemeConfig {
   description: string
   author: string
   navbarItems: HeaderItem[]
+  footerNavItems?: NavItem[]
   footerItems: NavItem[]
 
   locale: string
@@ -79,6 +80,7 @@ const defaults = {
   scrollProgress: false,
   scrollToTop: true,
   tagIcons: {},
+  footerNavItems: [] as NavItem[],
   shikiThemes: {
     light: 'vitesse-light',
     dark: 'vitesse-black'

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "theunnamedroads.com" }],
+      "destination": "https://www.theunnamedroads.com/:path*",
+      "permanent": true
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #15

## Din tur

Vercel Preview-URL visas i PR-checks när deployen är klar.

Efter merge: ta bort dig som assignee (GitHub nollställer den inte).

## Vad som ändrades

- Homepage: synlig FAQ-sektion + FAQPage JSON-LD; Person-schema (Emil Ingemar Karlsson → Organization) på startsidan
- Nav: Projects · Field Notes · About · Insights i header; Stack/Tools/Contact/For assistants i footer
- `/posts` titel och H1 = **Field Notes**
- Sitemap-filter: taggar, paginering, services och typo-slug borttagna; `/sitemap.xml` → `sitemap-index.xml`
- IndexNow: publik nyckelfil `741e73bc05ca4ca8b93944e7e9231f99.txt`
- `vercel.json`: apex `theunnamedroads.com` → `www` (301)

Company OS insight behåller befintlig FAQPage JSON-LD.

## Verifiering

- `pnpm check` och `pnpm build` grönt
- Byggd startsida har FAQ + Person i JSON-LD
- `/posts/` titel: Field Notes
- Sitemap innehåller inte `/tags/` eller `/posts/2`
- IndexNow-nyckel finns i `dist/`

## Learnings

- Astro `@astrojs/sitemap` `filter` tar full URL — testa med `page.replace(site, '')` för path-regex
- IndexNow `keyLocation` måste matcha publik `.txt` under `public/`; uppdatera `host` till `www` när canonical är www
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3479bf2-3e7f-412d-a151-c1b0dd05aa2a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3479bf2-3e7f-412d-a151-c1b0dd05aa2a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

