### PR TITLE
feat(brand): lock expedition positioning P0 (#91)

### DIFF
--- a/src/components/HomepageShell.astro
+++ b/src/components/HomepageShell.astro
@@ -73,7 +73,14 @@ const ventureProjects = featuredProjects.map((project) => {
 const ventureCards =
   ventureProjects.length > 0 ? ventureProjects : homepageData.ventures.companies
 
-const heroLoop = homepageData.hero.controlLoop
+const heroPrimaryCta = homepageData.hero.primaryCta ?? {
+  label: 'Read Field Notes',
+  href: '/posts/'
+}
+const heroSecondaryCta = homepageData.hero.secondaryCta ?? {
+  label: "See what's in flight",
+  href: '/projects/'
+}
 ---
 
 <div class="homepage-shell space-y-12 sm:space-y-16 lg:space-y-20">
@@ -81,75 +88,44 @@ const heroLoop = homepageData.hero.controlLoop
   <section class="hero" data-reveal>
     <p class="section-eyebrow">{homepageData.hero.eyebrow}</p>
     <h1 class="hero-headline mt-3">{homepageData.hero.headline}</h1>
-    <p class="hero-lead">
-      <strong>{homepageData.hero.eyebrow}</strong>
-      {
+    {
+      homepageData.hero.subheadline ? (
+        <p class="hero-lead">{homepageData.hero.subheadline}</p>
+      ) : (
         homepageData.hero.eyebrowAfter && (
-          <> — {homepageData.hero.eyebrowAfter}</>
+          <p class="hero-lead">{homepageData.hero.eyebrowAfter}</p>
         )
-      }
-    </p>
+      )
+    }
+    {
+      homepageData.hero.supportingLine && (
+        <p
+          class="hero-support mt-4 max-w-2xl text-sm leading-relaxed sm:text-base"
+          style="color: var(--roads-text-muted)"
+        >
+          {homepageData.hero.supportingLine}
+        </p>
+      )
+    }
     <div class="hero-ctas">
       <a
-        href="#ventures"
+        href={heroPrimaryCta.href}
         class="btn-primary"
         data-ph-event="cta_click"
-        data-ph-cta-id="hero_ventures"
+        data-ph-cta-id="hero_primary"
         data-ph-section="hero"
       >
-        View portfolio
+        {heroPrimaryCta.label}
       </a>
       <a
-        href="/insights"
+        href={heroSecondaryCta.href}
         class="btn-secondary"
         data-ph-event="cta_click"
-        data-ph-cta-id="hero_insights"
+        data-ph-cta-id="hero_secondary"
         data-ph-section="hero"
       >
-        Read Field Notes
+        {heroSecondaryCta.label}
       </a>
-    </div>
-
-    <div class="loop-panel" aria-label={heroLoop.loopLabel}>
-      <div class="loop-header">
-        <span class="loop-label">{heroLoop.platformLabel}</span>
-        {
-          heroLoop.liveLabel && (
-            <span class="loop-live">
-              <span class="loop-live-dot" aria-hidden="true" />
-              {heroLoop.liveLabel}
-            </span>
-          )
-        }
-      </div>
-      <p class="loop-label mb-3">{heroLoop.loopLabel}</p>
-      <div class="loop-steps">
-        {
-          heroLoop.steps.map((step) => (
-            <div class="loop-step">
-              <p class="loop-step-label">{step.label}</p>
-              <p class="loop-step-detail">{step.detail}</p>
-            </div>
-          ))
-        }
-      </div>
-      <div class="loop-gate">
-        <span class="loop-gate-pill">{heroLoop.gate.label}</span>
-        <span class="loop-gate-detail">{heroLoop.gate.detail}</span>
-      </div>
-      {
-        heroLoop.portfolio.href && (
-          <a
-            href={heroLoop.portfolio.href}
-            class="mt-3 inline-block text-sm font-medium text-accent transition-colors hover:underline"
-            data-ph-event="cta_click"
-            data-ph-cta-id="hero_portfolio"
-            data-ph-section="control_loop"
-          >
-            {heroLoop.portfolio.detail} →
-          </a>
-        )
-      }
     </div>
   </section>
 
@@ -265,50 +241,26 @@ const heroLoop = homepageData.hero.controlLoop
     </div>
   </section>
 
-  <!-- Company OS archive -->
   {
-    homepageData.companyOs && (
-      <section id="company-os" class="section-shell space-y-5" data-reveal>
-        <header class="space-y-3">
-          <p class="section-eyebrow">{homepageData.companyOs.eyebrow}</p>
-          <h2 class="section-title">{homepageData.companyOs.title}</h2>
-          <p class="section-lead">{homepageData.companyOs.description}</p>
-          {homepageData.companyOs.statusNote && (
-            <p
-              class="text-sm font-medium"
-              style="color: var(--roads-text-soft)"
-            >
-              {homepageData.companyOs.statusNote}
-            </p>
-          )}
-          <div class="flex flex-wrap gap-3 pt-2">
-            <a
-              href={homepageData.companyOs.primaryCta.href}
-              class="btn-primary"
-              data-ph-event="cta_click"
-              data-ph-cta-id="company_os_explainer"
-              data-ph-section="company_os"
-            >
-              {homepageData.companyOs.primaryCta.label}
-            </a>
-            {homepageData.companyOs.secondaryCta && (
-              <a
-                href={homepageData.companyOs.secondaryCta.href}
-                class="btn-secondary"
-                data-ph-event="cta_click"
-                data-ph-cta-id="company_os_field_notes"
-                data-ph-section="company_os"
-              >
-                {homepageData.companyOs.secondaryCta.label}
-              </a>
-            )}
-          </div>
-        </header>
+    homepageData.fieldNotesTeaser && (
+      <section class="section-shell space-y-4" data-reveal>
+        <p class="section-eyebrow">{homepageData.fieldNotesTeaser.eyebrow}</p>
+        <h2 class="section-title">{homepageData.fieldNotesTeaser.title}</h2>
+        <p class="section-lead">{homepageData.fieldNotesTeaser.description}</p>
+        <a
+          href={homepageData.fieldNotesTeaser.href}
+          class="inline-flex text-sm font-semibold text-accent"
+          data-ph-event="cta_click"
+          data-ph-cta-id="field_notes_teaser"
+          data-ph-section="field_notes"
+        >
+          {homepageData.fieldNotesTeaser.linkLabel} →
+        </a>
       </section>
     )
   }
 
-  <!-- How we ship -->
+  <!-- How we ship (below fold — operational detail, not brand hero) -->
   <section id="operating-system" class="section-shell space-y-8" data-reveal>
     <header class="space-y-3">
       <p class="section-eyebrow">{homepageData.operatingSystem.eyebrow}</p>
@@ -343,25 +295,6 @@ const heroLoop = homepageData.hero.controlLoop
       }
     </ol>
   </section>
-
-  {
-    homepageData.fieldNotesTeaser && (
-      <section class="section-shell space-y-4" data-reveal>
-        <p class="section-eyebrow">{homepageData.fieldNotesTeaser.eyebrow}</p>
-        <h2 class="section-title">{homepageData.fieldNotesTeaser.title}</h2>
-        <p class="section-lead">{homepageData.fieldNotesTeaser.description}</p>
-        <a
-          href={homepageData.fieldNotesTeaser.href}
-          class="inline-flex text-sm font-semibold text-accent"
-          data-ph-event="cta_click"
-          data-ph-cta-id="field_notes_teaser"
-          data-ph-section="field_notes"
-        >
-          {homepageData.fieldNotesTeaser.linkLabel} →
-        </a>
-      </section>
-    )
-  }
 
   {
     homepageData.stackStrip && (

--- a/src/content/homepage/structure.json
+++ b/src/content/homepage/structure.json
@@ -1,8 +1,17 @@
 {
   "hero": {
-    "eyebrow": "AI venture studio",
-    "eyebrowAfter": "3 Focus bets, 12-week experiments — human Approve before publish, deploy, or external send.",
+    "eyebrow": "Expedition studio",
     "headline": "The Unnamed Roads",
+    "subheadline": "The map is full. But there are still roads without names — and one developer can take them now. AI carries the pack. You hold the compass.",
+    "supportingLine": "It used to take a team. Now one developer + AI automation walks terrain that wasn't on the map — expedition, not agency.",
+    "primaryCta": {
+      "label": "Read Field Notes",
+      "href": "/posts/"
+    },
+    "secondaryCta": {
+      "label": "See what's in flight",
+      "href": "/projects/"
+    },
     "badges": [],
     "controlLoop": {
       "windowTitle": "Studio · Control loop",
@@ -544,8 +553,8 @@
   },
   "fieldNotesTeaser": {
     "eyebrow": "Field Notes",
-    "title": "Evidence from building in public",
-    "description": "Measured experiments, approval gates and portfolio policy — written for indie founders shipping AI-native companies without heavy org debt.",
+    "title": "Dispatches from the road",
+    "description": "Receipts from building in public — measured experiments, costs, and outcomes. Not a manifesto; evidence you can cite.",
     "href": "/posts/",
     "linkLabel": "Read Field Notes"
   },

--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -1,7 +1,7 @@
 ---
 layout: '@/layouts/PageLayout.astro'
 title: About — The Unnamed Roads
-description: "One-operator AI-native venture studio in Stockholm. Bounded Focus bets, measured experiments, human Approve gates — and open Field Notes."
+description: "Stockholm expedition studio — one developer, roads the map doesn't name. AI carries the pack; human Approve before anything leaves camp. Open Field Notes."
 activeHeaderLink: About
 fullBleed: true
 ---
@@ -12,8 +12,10 @@ fullBleed: true
       <p class="section-eyebrow">Studio</p>
       <h1 class="text-4xl font-semibold text-white sm:text-5xl">The Unnamed Roads</h1>
       <p class="text-base text-slate-300 sm:text-lg">
-        A one-operator AI-native venture studio in Stockholm. We run a <strong class="text-white">bounded Focus set</strong> with
-        measured experiments and human Approve gates — not dashboard-first busywork.
+        Stockholm · one developer · roads the map doesn't name · AI carries · Approve before anything leaves camp.
+      </p>
+      <p class="text-base text-slate-400 sm:text-lg">
+        The map is full, but unnamed roads still exist. One developer with AI automation can walk them now — expedition, not agency.
       </p>
     </div>
     <div class="grid gap-4 md:grid-cols-2">
@@ -21,42 +23,21 @@ fullBleed: true
         <p class="text-xs uppercase tracking-[0.4em] text-slate-400">Operator</p>
         <p class="mt-2 text-lg font-semibold text-white">Emil Ingemar Karlsson — Stockholm</p>
         <p class="mt-2 text-sm text-slate-300">
-          Strategy, irreversible decisions and publish gates — approved on phone, not in meetings.
+          Holds the compass — strategy, irreversible decisions and publish gates, approved on phone, not in meetings.
           Personal realm: <a class="text-accent underline" href="https://emilingemarkarlsson.com" rel="noopener noreferrer">emilingemarkarlsson.com</a> (separate from studio bets).
         </p>
       </div>
       <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
         <p class="text-xs uppercase tracking-[0.4em] text-slate-400">Operating stance</p>
-        <p class="mt-2 text-lg font-semibold text-white">Agents inside policy — never as fake executives.</p>
-        <p class="mt-2 text-sm text-slate-300">Automation accelerates proven workflows; consequential external actions stay human-gated.</p>
+        <p class="mt-2 text-lg font-semibold text-white">AI carries the pack — never fake executives.</p>
+        <p class="mt-2 text-sm text-slate-300">Automation accelerates proven workflows; consequential external actions stay human-gated. See <a class="text-accent underline" href="/agents/">/agents/</a> for policy-bound roles.</p>
       </div>
     </div>
   </section>
 
-  <section class="section-shell space-y-4">
-    <p class="section-eyebrow">How we decide</p>
-    <p class="text-base text-slate-300">
-      Every venture sits in one lane — no portfolio spray. Full policy: <a class="text-accent underline" href="/insights/focus-monitor-parked">Focus · Monitor · Parked</a>.
-    </p>
-    <div class="grid gap-4 sm:grid-cols-3">
-      <article class="signal-card space-y-2">
-        <span class="status-pill text-emerald-300 border-emerald-400/30 bg-emerald-500/10">Focus</span>
-        <p class="text-sm text-slate-300">At most three bets with active validation contracts and daily growth execution.</p>
-      </article>
-      <article class="signal-card space-y-2">
-        <span class="status-pill text-sky-300 border-sky-400/30 bg-sky-500/10">Monitor</span>
-        <p class="text-sm text-slate-300">Live products watched for signal — not daily growth, but not parked either.</p>
-      </article>
-      <article class="signal-card space-y-2">
-        <span class="status-pill text-slate-300 border-slate-400/30 bg-slate-500/10">Parked</span>
-        <p class="text-sm text-slate-300">Honest archive — explainer kept, no pretend momentum.</p>
-      </article>
-    </div>
-  </section>
-
   <section class="section-shell space-y-6">
-    <p class="section-eyebrow">Focus proof (live)</p>
-    <p class="text-base text-slate-300">Current Focus bets with honest status — not a manifesto, just what ships.</p>
+    <p class="section-eyebrow">What's in flight</p>
+    <p class="text-base text-slate-300">Live projects with honest status — impossible playbooks, not a manifesto.</p>
     <div class="grid gap-4 md:grid-cols-2">
       <article class="signal-card space-y-2">
         <div class="flex flex-wrap items-center gap-2">
@@ -79,16 +60,8 @@ fullBleed: true
           <h2 class="text-lg font-semibold text-white">TUR Field Notes</h2>
           <span class="status-pill text-emerald-300 border-emerald-400/30 bg-emerald-500/10">Focus</span>
         </div>
-        <p class="text-sm text-slate-300">Open experiments with decisions, costs, outcomes and playbooks — subscribe for signal.</p>
+        <p class="text-sm text-slate-300">Dispatches from the road — decisions, costs, outcomes and playbooks.</p>
         <a href="/posts/" class="text-sm font-semibold text-accent">Browse Field Notes →</a>
-      </article>
-      <article class="signal-card space-y-2">
-        <div class="flex flex-wrap items-center gap-2">
-          <h2 class="text-lg font-semibold text-white">TUR Company OS</h2>
-          <span class="status-pill text-slate-300 border-slate-400/30 bg-slate-500/10">Avvecklat</span>
-        </div>
-        <p class="text-sm text-slate-300">Platform wound down September 2026 — explainer kept for reference, not active Focus.</p>
-        <a href="/insights/ai-native-venture-studio-operating-system" class="text-sm font-semibold text-accent">Read the explainer →</a>
       </article>
     </div>
     <p class="text-sm text-slate-400">10+ live ventures total — <a class="text-accent underline" href="/projects">see the full portfolio</a> with honest status labels.</p>
@@ -96,14 +69,35 @@ fullBleed: true
 
   <section class="section-shell space-y-4 text-center">
     <h2 class="text-2xl font-semibold text-white">Follow the work</h2>
-    <p class="mx-auto max-w-2xl text-base text-slate-300">We publish measured experiments, not manifestos. Start with Field Notes or browse the portfolio.</p>
+    <p class="mx-auto max-w-2xl text-base text-slate-300">Field Notes are receipts from the road — measured experiments, not manifestos.</p>
     <div class="flex flex-col gap-3 pt-2 sm:flex-row sm:justify-center">
       <a href="/posts/" class="inline-flex items-center justify-center gap-2 rounded-2xl bg-white px-6 py-3 font-semibold text-gray-900">
         Read Field Notes
       </a>
       <a href="/projects" class="inline-flex items-center justify-center gap-2 rounded-2xl border border-white/40 px-6 py-3 font-semibold text-white">
-        Browse projects
+        See what's in flight
       </a>
+    </div>
+  </section>
+
+  <section class="section-shell space-y-4 border-t border-white/10 pt-10">
+    <p class="section-eyebrow">Portfolio taxonomy</p>
+    <p class="text-base text-slate-400">
+      Internal status labels — not the brand story. Full policy: <a class="text-accent underline" href="/insights/focus-monitor-parked">Focus · Monitor · Parked</a>.
+    </p>
+    <div class="grid gap-4 sm:grid-cols-3">
+      <article class="signal-card space-y-2">
+        <span class="status-pill text-emerald-300 border-emerald-400/30 bg-emerald-500/10">Focus</span>
+        <p class="text-sm text-slate-400">Active validation contracts on bounded product bets.</p>
+      </article>
+      <article class="signal-card space-y-2">
+        <span class="status-pill text-sky-300 border-sky-400/30 bg-sky-500/10">Monitor</span>
+        <p class="text-sm text-slate-400">Live products watched for signal — honest status, not parked.</p>
+      </article>
+      <article class="signal-card space-y-2">
+        <span class="status-pill text-slate-300 border-slate-400/30 bg-slate-500/10">Parked / Avvecklat</span>
+        <p class="text-sm text-slate-400">Archive with explainer kept — no pretend momentum.</p>
+      </article>
     </div>
   </section>
 </div>

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -1,18 +1,18 @@
 ---
 layout: '@/layouts/PageLayout.astro'
-title: The Unnamed Roads | AI Venture Studio + Approve Gates
-description: "One-operator Stockholm studio: 3 Focus bets, 12-week experiments, human Approve before publish. Open Field Notes—not a consulting hire funnel."
+title: The Unnamed Roads | One developer. Unnamed roads.
+description: "The map is full — one developer + AI automation walks terrain that wasn't on the map. Field Notes receipts from the road; expedition, not agency. Human Approve before anything leaves camp."
 activeHeaderLink: Home
 fullBleed: true
 faq:
   - question: "What is The Unnamed Roads?"
-    answer: "A one-operator AI-native venture studio in Stockholm. We run a bounded Focus set with measured experiments, human Approve gates, and open Field Notes — not a consulting hire funnel."
-  - question: "What does Focus mean in the portfolio?"
-    answer: "Focus projects have an active validation contract and measured experiments — currently three product bets (The Hockey Analytics, Föräldraledighetsplaneraren, and Field Notes on this site). Everything else is Monitor, Parked or Avvecklat. See the Focus · Monitor · Parked policy page."
-  - question: "How is Focus different from the SEO/dev attention set?"
-    answer: "Focus is product validation — three bets with falsifiable contracts. The SEO/dev attention set is eight live surfaces (EIK, TUR, THA, The Hockey Brain, Agent Fabric, Atomic Network, AI Automation Fabric, Print Route) that get daily crawl, copy, and technical SEO work. Föräldraledighetsplaneraren remains a Focus bet; family-cluster SEO is deferred, not abandoned."
+    answer: "An expedition studio — one developer in Stockholm walking roads the map doesn't name. AI carries the pack; the operator holds the compass. Open Field Notes with receipts from the road — not a consulting hire funnel."
   - question: "Do agents publish or send outbound autonomously?"
     answer: "No. Agents draft and research inside policy. Publish, deploy and external send require explicit human Approve — typically on phone, not in meetings."
+  - question: "What does Focus mean in the portfolio?"
+    answer: "Focus is internal portfolio taxonomy — active validation contracts on a bounded set of product bets. Status labels (Focus, Monitor, Parked, Avvecklat) stay honest on project cards; they are not the brand story. See Focus · Monitor · Parked for the full policy."
+  - question: "Is this an agency or AI-autonomy theater?"
+    answer: "Neither. Expedition, not agency — one developer with AI automation, human Approve gates, and Field Notes as receipts. No fake executive team; see /agents/ for how workflow roles are described."
 ---
 
 import HomepageShell from '@/components/HomepageShell.astro'
@@ -24,19 +24,19 @@ import HomepageShell from '@/components/HomepageShell.astro'
   <dl class="space-y-5">
     <div>
       <dt class="font-semibold text-white">What is The Unnamed Roads?</dt>
-      <dd class="mt-1 text-slate-300">A one-operator AI-native venture studio in Stockholm. We run a bounded Focus set with measured experiments, human Approve gates, and open Field Notes — not a consulting hire funnel.</dd>
-    </div>
-    <div>
-      <dt class="font-semibold text-white">What does Focus mean in the portfolio?</dt>
-      <dd class="mt-1 text-slate-300">Focus projects have an active validation contract and measured experiments — currently three product bets (The Hockey Analytics, Föräldraledighetsplaneraren, and Field Notes on this site). Everything else is Monitor, Parked or Avvecklat. See <a class="text-accent underline" href="/insights/focus-monitor-parked">Focus · Monitor · Parked</a>.</dd>
-    </div>
-    <div>
-      <dt class="font-semibold text-white">How is Focus different from the SEO/dev attention set?</dt>
-      <dd class="mt-1 text-slate-300">Focus is product validation — three bets with falsifiable contracts. The SEO/dev attention set is eight live surfaces (EIK, TUR, THA, The Hockey Brain, Agent Fabric, Atomic Network, AI Automation Fabric, Print Route) that get daily crawl, copy, and technical SEO work. Föräldraledighetsplaneraren remains a Focus bet; family-cluster SEO is deferred, not abandoned.</dd>
+      <dd class="mt-1 text-slate-300">An expedition studio — one developer in Stockholm walking roads the map doesn't name. AI carries the pack; the operator holds the compass. Open Field Notes with receipts from the road — not a consulting hire funnel.</dd>
     </div>
     <div>
       <dt class="font-semibold text-white">Do agents publish or send outbound autonomously?</dt>
       <dd class="mt-1 text-slate-300">No. Agents draft and research inside policy. Publish, deploy and external send require explicit human Approve — typically on phone, not in meetings.</dd>
+    </div>
+    <div>
+      <dt class="font-semibold text-white">What does Focus mean in the portfolio?</dt>
+      <dd class="mt-1 text-slate-300">Focus is internal portfolio taxonomy — active validation contracts on a bounded set of product bets. Status labels (Focus, Monitor, Parked, Avvecklat) stay honest on project cards; they are not the brand story. See <a class="text-accent underline" href="/insights/focus-monitor-parked">Focus · Monitor · Parked</a>.</dd>
+    </div>
+    <div>
+      <dt class="font-semibold text-white">Is this an agency or AI-autonomy theater?</dt>
+      <dd class="mt-1 text-slate-300">Neither. Expedition, not agency — one developer with AI automation, human Approve gates, and Field Notes as receipts. No fake executive team; see <a class="text-accent underline" href="/agents/">/agents/</a> for how workflow roles are described.</dd>
     </div>
   </dl>
 </section>

--- a/src/pages/insights.astro
+++ b/src/pages/insights.astro
@@ -14,9 +14,9 @@ const totalPages = Math.ceil(posts.length / config.postsPerPage)
 const currentPosts = posts.slice(0, config.postsPerPage)
 
 const frontmatter = {
-  title: 'Insights — Experimentation Frameworks & AI-Human Collaboration',
+  title: 'Insights — Expedition Receipts & Frameworks',
   description:
-    'Frameworks, field notes, and learnings from our experiments: 12-week methodology, AI as co-founder, anonymity, and post-human entrepreneurship. Real ops, real signal.',
+    'Frameworks and field receipts from one-developer expeditions: measured experiments, compass/pack collaboration, and honest portfolio ops — expedition, not agency.',
   activeHeaderLink: 'Insights',
   fullBleed: true
 }
@@ -28,12 +28,12 @@ const frontmatter = {
       <p class="section-eyebrow">Field notes</p>
       <div class="space-y-6">
         <h1 class="text-4xl font-semibold text-white sm:text-5xl">
-          Insights &amp; learnings from the lab
+          Insights from the road
         </h1>
         <p class="mx-auto max-w-3xl text-base text-slate-300 sm:text-lg">
-          Documenting experiments, failures, and frameworks uncovered while
-          building anonymously with AI. Every post captures signal pulled from
-          real ops.
+          Frameworks and receipts from walking unnamed roads — measured
+          experiments, honest portfolio ops, and policy-bound automation.
+          Expedition voice; useful history preserved.
         </p>
       </div>
       <div class="flex flex-col gap-3 pt-2 sm:flex-row sm:justify-center">
@@ -66,9 +66,8 @@ const frontmatter = {
           <p class="section-eyebrow">Latest drops</p>
           <h2 class="text-3xl font-semibold text-white">Fresh intelligence</h2>
           <p class="mt-2 max-w-2xl text-slate-300">
-            We publish only when the data is interesting—expect sharp takes on
-            AI-native venture design, operating cadence, and experimentation
-            rituals.
+            Published when the data is interesting — sharp takes on expedition
+            ops, experimentation rituals, and compass/pack collaboration.
           </p>
         </div>
         {
@@ -91,8 +90,8 @@ const frontmatter = {
         <p class="section-eyebrow">Topical pillars</p>
         <h2 class="text-3xl font-semibold text-white">Core knowledge areas</h2>
         <p class="mt-2 max-w-2xl text-slate-300">
-          Our content is organized around these foundational pillars that
-          establish topical authority in AI-native venture building.
+          Organized knowledge areas — reframed where older posts used co-founder
+          or post-human language; history stays linked, voice stays expedition.
         </p>
       </div>
       <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -101,21 +100,21 @@ const frontmatter = {
           class="signal-card block space-y-2"
         >
           <h3 class="text-xl font-semibold text-white">
-            AI-Human Collaboration
+            Compass &amp; Pack Collaboration
           </h3>
           <p class="text-sm text-slate-300">
-            Frameworks, practices, and mental models for treating AI as a
-            strategic co-founder rather than a tool.
+            AI carries repetitive load; the human holds the compass and Approve
+            gates — not AI-as-co-founder theater.
           </p>
         </a>
         <a
           href="/insights/auto-agent-workflows"
           class="signal-card block space-y-2"
         >
-          <h3 class="text-xl font-semibold text-white">Auto Agent Workflows</h3>
+          <h3 class="text-xl font-semibold text-white">Policy-Bound Agents</h3>
           <p class="text-sm text-slate-300">
-            Proactive AI agents that generate work for approval and execution.
-            Building a team of autonomous agents.
+            Agents propose inside policy; humans Approve before publish or
+            external send. Pack-carriers, not fake executive teams.
           </p>
         </a>
         <a
@@ -135,11 +134,12 @@ const frontmatter = {
           class="signal-card block space-y-2"
         >
           <h3 class="text-xl font-semibold text-white">
-            Post-Human Entrepreneurship
+            One-Developer Expedition
           </h3>
           <p class="text-sm text-slate-300">
-            The paradigm shift where single operators achieve corporate-scale
-            output through AI symbiosis.
+            Walking terrain the map doesn't name — one developer + AI
+            automation, expedition not agency. Reframed from earlier post-human
+            essays.
           </p>
         </a>
         <a
@@ -167,21 +167,21 @@ const frontmatter = {
           class="signal-card block space-y-2"
         >
           <h3 class="text-xl font-semibold text-white">
-            Venture Studio Operations
+            Expedition Studio Operations
           </h3>
           <p class="text-sm text-slate-300">
-            Operating AI-native venture studios. Portfolio management, parallel
-            experiments, and scalable venture creation.
+            One-developer portfolio ops — honest status labels, parallel
+            experiments, human Approve gates.
           </p>
         </a>
         <a
           href="/insights/ai-native-venture-studio-operating-system"
           class="signal-card block space-y-2"
         >
-          <h3 class="text-xl font-semibold text-white">Company OS</h3>
+          <h3 class="text-xl font-semibold text-white">Company OS (archive)</h3>
           <p class="text-sm text-slate-300">
-            Decision-first operating system for AI-native studios — control
-            plane, approval gates and learning loops.
+            Historical operating-system essay — platform Avvecklat; Approve
+            gates and learning loops remain operational truth.
           </p>
         </a>
         <a

--- a/src/pages/insights/ai-human-collaboration.mdx
+++ b/src/pages/insights/ai-human-collaboration.mdx
@@ -1,82 +1,54 @@
 ---
 layout: '@/layouts/PageLayout.astro'
-title: AI-Human Collaboration Methodology
-description: Complete guide to treating AI as a strategic co-founder. Frameworks, practices, and mental models for hybrid intelligence in business building.
+title: AI-Human Collaboration — Compass and Pack
+description: AI carries the pack; the human holds the compass. Policy-bound collaboration for one-developer expeditions — not AI-as-co-founder theater.
 faq:
   - question: "How do you structure daily collaboration with AI?"
-    answer: "We use structured morning standups with AI: share context, priorities, and blockers; get analysis and alternatives. We also run idea sparring sessions for new concepts and devil's advocate sessions before major decisions. See our AI as Co-Founder article for the full framework."
+    answer: "Morning signal review: share context and priorities; AI drafts analysis and alternatives inside policy. Major external actions wait for human Approve — publish, deploy, and outbound send are never autonomous. See Field Notes for operational receipts."
   - question: "What decisions should AI make vs humans?"
-    answer: "AI decides data analysis, pattern identification, alternative generation, and first-draft outputs. Humans decide strategy, relationships, final execution choices, and when to override. We define clear decision rights and use mandatory human-only periods for major choices."
-  - question: "What's the difference between using AI tools and AI as co-founder?"
-    answer: "AI as a tool means you prompt and it responds. AI as co-founder means structured routines (standups, sparring, devil's advocate), shared context and memory, and clear handoffs between AI phases (analysis, planning) and human phases (building, relationships, final calls). The dynamic and output quality change completely."
-  - question: "How do you measure if AI collaboration is working?"
-    answer: "We track problem identification speed, number of alternatives explored per decision, reduction in emotional decision delays, and experiment success rate. Our 6-month co-founding experiment showed 78% faster problem identification and 45% increase in experiment success rate."
+    answer: "AI handles research breadth, first drafts, pattern surfacing, and routine execution inside spend/policy gates. Humans hold the compass: strategy, relationships, irreversible choices, and every Approve gate before anything leaves camp."
+  - question: "What's the difference between AI tools and expedition collaboration?"
+    answer: "Tools respond to prompts. Expedition collaboration means bounded workflows with shared context, explicit Approve checkpoints, and honest receipts in Field Notes — AI carries repetitive load; the operator steers."
 ---
 
-# AI-Human Collaboration Methodology
+# AI-Human Collaboration — Compass and Pack
 
-**Pillar Page** | Part of our [AI-Native Venture Building](/insights) topical authority
+**Pillar Page** | Part of our [Insights](/insights) archive
 
-This pillar establishes the foundational philosophy and practical frameworks for treating AI as a co-founder rather than a tool. It's the core differentiator that positions this site as the authority on strategic AI use in business building.
+The locked positioning: **AI carries the pack. You hold the compass.** This pillar documents how that works in practice — without AI-as-co-founder theater.
 
 ## Core Concept
 
-AI-native building isn't about using AI tools—it's about creating a **hybrid intelligence** where human creativity and machine capability merge to achieve superhuman output. This pillar covers the methodology, frameworks, and mental models that make this possible.
+One-developer expeditions need load-sharing, not fake executives. AI accelerates proven workflows under policy; humans retain compass duties and Approve gates before external send.
 
 ## Key Topics Covered
 
-### Daily Collaboration Routines
-- Structured morning standups with AI
-- Context management across long conversations
-- Decision-making frameworks with AI input
-- When to trust vs verify AI suggestions
+### Daily collaboration
+- Signal → draft → Approve → publish (separate gates)
+- Context management without autonomy theater
+- When to trust drafts vs verify before Approve
 
-### Strategic Frameworks
-- AI as co-founder vs AI as tool
-- Decision rights: what AI decides vs what humans decide
-- Measuring AI collaboration effectiveness
-- Balancing human intuition with AI analysis
+### Decision rights
+- Pack work: research, drafts, routine execution inside policy
+- Compass work: strategy, relationships, irreversible calls
+- Measuring outcomes in Field Notes, not vanity autonomy metrics
 
-### Implementation Guides
-- Setting up AI memory systems
-- Building AI team member integration
-- Creating AI collaboration workflows
-- Tools and infrastructure for AI partnership
+### Implementation
+- Policy-bound agent roles (see [/agents/](/agents/))
+- Approve on phone, not in meetings
+- Infrastructure reference on [/tools/](/tools/)
 
 ## Featured Content
 
 ### Essential Reading
-- [AI as Co-Founder: Lessons from 6 Months](/posts/ai-as-cofounder) - Our foundational article on treating AI as a strategic partner
-- [The Post-Human Entrepreneur](/posts/the-post-human-entrepreneur) - The philosophical foundation of hybrid intelligence
+- [AI as Co-Founder: Lessons from 6 Months](/posts/ai-as-cofounder) — historical essay; read as early compass/pack exploration
+- [How I Run 7 Sites With One Person and AI Agents](/posts/how-i-run-7-sites-with-one-person-and-ai-agents) — operational receipts
 
 ### Related Pillars
-- [Rapid Experimentation Frameworks](/insights/experimentation-frameworks) - How AI collaboration accelerates experimentation
-- [Post-Human Entrepreneurship](/insights/post-human-entrepreneurship) - The broader paradigm shift
-- [AI Tool Stack](/tools) - Practical tools that enable AI collaboration
-
-## Common Questions Answered
-
-This pillar answers questions like:
-- How do you structure daily collaboration with AI?
-- What decisions should AI make vs humans?
-- How do you maintain context across long AI conversations?
-- What's the difference between using AI tools and AI as co-founder?
-- How do you measure if AI collaboration is working?
-- What are the risks of over-relying on AI?
-
-## Search Intent Coverage
-
-This pillar captures searches for:
-- "how to use AI as co-founder"
-- "AI collaboration framework"
-- "human AI partnership business"
-- "AI native entrepreneurship"
-- "solo founder with AI"
-- "AI strategic partner"
-- "post-human entrepreneur"
-- "hybrid intelligence business"
+- [Auto Agent Workflows](/insights/auto-agent-workflows) — policy-bound agents, not autonomous teams
+- [One-Developer Expedition](/insights/post-human-entrepreneurship) — expedition framing
+- [Focus · Monitor · Parked](/insights/focus-monitor-parked) — portfolio taxonomy
 
 ---
 
-_This is a living document. As we publish new content on AI-human collaboration, it will be added here to maintain topical authority._
-
+_This pillar reframes earlier co-founder language into compass/pack expedition voice. Linked history stays available._

--- a/src/pages/insights/auto-agent-workflows.mdx
+++ b/src/pages/insights/auto-agent-workflows.mdx
@@ -1,104 +1,63 @@
 ---
 layout: '@/layouts/PageLayout.astro'
-title: Auto Agent Workflows
-description: Proactive AI agents that generate work for approval and execution. Autonomous agents that solo operators collaborate with to scale operations without hiring.
+title: Policy-Bound Agent Workflows
+description: Agents draft and execute inside policy — human Approve before publish, deploy, or external send. Pack-carriers for one-developer expeditions, not autonomous executive teams.
 faq:
-  - question: "What's the difference between reactive and proactive AI agents?"
-    answer: "Reactive agents wait for instructions or triggers (e.g. when X happens, do Y). Proactive agents monitor, analyze, and generate work for you to approve—they suggest next steps and execute after your review. Proactive agents enable true solo-operator scaling without hiring."
+  - question: "What's the difference between reactive and proactive agents?"
+    answer: "Reactive agents wait for triggers. Proactive agents monitor and propose work for Approve — they do not publish or send outbound autonomously. The operator holds the compass; agents carry pack weight inside policy."
   - question: "How do you set up approval workflows for AI agents?"
-    answer: "Define human-in-the-loop checkpoints: agents propose actions or content, you review and approve or reject. Use clear escalation rules and exception handling. Balance autonomy (agents run routine tasks) with control (humans approve strategy, spend, and public-facing output)."
-  - question: "What infrastructure do you need for autonomous AI agents?"
-    answer: "Agents need context and memory (e.g. shared docs or vector stores), secure API access, and observability (logs, metrics). Our stack uses Coolify, LiteLLM, and workflow tools so agents can run reliably and be monitored. Start with one agent and one approval loop before scaling."
-  - question: "How do proactive agents help solo operators scale?"
-    answer: "Proactive agents generate tasks and proposals so you spend time approving and directing instead of doing every step yourself. One operator can run multiple experiments or products by having agents handle research, drafts, and routine execution while you make decisions and hold relationships."
+    answer: "Define Approve checkpoints before any external action: drafts, deploys, outbound send. Agents propose; humans Approve, defer, or reject — typically on phone. See /agents/ for how roles are described (not fake executives)."
+  - question: "What infrastructure do you need for policy-bound agents?"
+    answer: "Shared context, secure API access, observability, and spend gates. Start with one workflow and one Approve loop before scaling. Stack reference: /tools/ and /stack/."
 ---
 
-# Auto Agent Workflows
+# Policy-Bound Agent Workflows
 
-**Pillar Page** | Part of our [AI-Native Venture Building](/insights) topical authority
+**Pillar Page** | Part of our [Insights](/insights) archive
 
-This pillar addresses the practical implementation layer: building proactive AI agents that work autonomously, generate proposals for your approval, and execute tasks after you've reviewed them. This is what enables true solo operator scaling.
+This pillar covers **agents inside policy** — pack-carriers on an expedition, not an autonomous C-suite.
 
 ## Core Concept
 
-While [AI-Human Collaboration](/insights/ai-human-collaboration) covers the philosophy of treating AI as a co-founder, this pillar addresses the concrete systems: **autonomous agents that work proactively** rather than waiting for instructions. These agents monitor, analyze, propose, and execute—creating a scalable team of AI workers that you collaborate with as the sole human operator.
+Agents monitor, draft, and propose. Humans Approve before anything leaves camp. That distinction is non-negotiable: no publish/deploy/external-send autonomy theater.
+
+While [AI-Human Collaboration](/insights/ai-human-collaboration) covers compass/pack philosophy, this pillar covers concrete workflows: bounded roles, Approve loops, and honest observability.
 
 ## Key Topics Covered
 
-### Agent Design & Architecture
-- Designing proactive vs reactive agents
-- Agent specialization and role definition
-- Agent memory and context management
-- Agent-to-agent communication patterns
-- Building agent teams for solo operators
+### Agent design
+- Proactive proposals vs autonomous execution (external)
+- Specialization without fake executive titles
+- Memory and context within policy bounds
+- Coordination without "agent swarm" brand theater
 
-### Approval & Review Workflows
-- Setting up approval workflows for AI agents
-- Review and validation processes
-- Human-in-the-loop decision points
+### Approve workflows
+- Human-in-the-loop before external send
 - Escalation and exception handling
-- Balancing autonomy with control
+- Approve · Defer · Reject on phone
 
-### Agent Orchestration
-- Coordinating multiple agents
-- Preventing agent conflicts
-- Agent task distribution
-- Agent monitoring and observability
-- Agent failure handling and recovery
-
-### Infrastructure & Security
-- Infrastructure requirements for AI agents
-- Agent security and access control
-- Agent deployment patterns
-- Agent testing and validation
-- Scaling from one agent to many
+### Infrastructure
+- Stack mapped to expedition phases — see [/tools/](/tools/)
+- Security and spend gates
+- Scaling from one workflow to many — still one compass
 
 ## Featured Content
 
-### Essential Projects
-- [Post-Human Venture Engine](/projects/post-human-venture-engine) — Our operating system of playbooks, agents, and self-healing pipelines
-- [The Agent Fabric](/projects/the-agent-fabric) — Distributed agent infrastructure for enterprise AI automation
+### Related projects
+- [The Agent Fabric](/projects/the-agent-fabric) — distributed agent infrastructure (Monitor status)
+- Field Notes on automation receipts — [/posts/](/posts/)
 
 ### Related Pillars
-- [AI-Human Collaboration Methodology](/insights/ai-human-collaboration) — The philosophy behind agent collaboration
-- [Venture Studio Operations](/insights/venture-studio-operations) — How agents enable portfolio-scale operations
-- [Post-Human Entrepreneurship](/insights/post-human-entrepreneurship) — The broader paradigm shift
+- [AI-Human Collaboration](/insights/ai-human-collaboration) — compass and pack
+- [Venture Studio Operations](/insights/venture-studio-operations) — one-developer portfolio ops
+- [One-Developer Expedition](/insights/post-human-entrepreneurship) — expedition framing
 
-## Common Questions Answered
+## Agents vs automation
 
-This pillar answers questions like:
-- How do you build AI agents that work proactively?
-- What's the difference between reactive and proactive agents?
-- How do you set up approval workflows for AI agents?
-- How do multiple AI agents coordinate together?
-- What happens when an AI agent makes a mistake?
-- How do you monitor what your AI agents are doing?
-- How do you give AI agents access to your systems safely?
-- What tasks should AI agents handle autonomously?
+**Traditional automation**: predefined workflows when triggered.
 
-## Search Intent Coverage
-
-This pillar captures searches for:
-- "autonomous AI agents for business"
-- "AI agents that generate work"
-- "proactive AI agents"
-- "AI agent approval workflows"
-- "solo operator AI agents"
-- "autonomous agent systems"
-- "AI agent orchestration"
-- "building AI agent team"
-- "agent-based automation"
-- "AI agents for solo founders"
-
-## The Difference: Agents vs Automation
-
-**Traditional Automation**: Executes predefined workflows when triggered. Requires explicit instructions.
-
-**Auto Agent Workflows**: Proactive agents that monitor, analyze, propose actions, and execute after approval. They work autonomously and generate work for you to review.
-
-This distinction is critical—agents don't just execute your commands; they **think, propose, and create** work that you approve and deploy.
+**Policy-bound agents**: monitor and propose; external execution waits for human Approve. They carry pack weight — they do not hold the compass.
 
 ---
 
-_This is a living document. As we publish new content on auto agent workflows, it will be added here to maintain topical authority._
-
+_This pillar reframes earlier autonomous-agent language into Approve-gated expedition ops._

--- a/src/pages/insights/post-human-entrepreneurship.mdx
+++ b/src/pages/insights/post-human-entrepreneurship.mdx
@@ -1,82 +1,67 @@
 ---
 layout: '@/layouts/PageLayout.astro'
-title: Post-Human Entrepreneurship
-description: The paradigm shift where single operators achieve corporate-scale output through AI symbiosis. The death of traditional startup infrastructure.
+title: One-Developer Expedition — Beyond the Map
+description: One developer with AI automation walking terrain the map doesn't name. Expedition studio receipts — not post-human theater or agency-scale claims.
 faq:
-  - question: "What is post-human entrepreneurship?"
-    answer: "Post-human entrepreneurship is building at scale as a single operator by partnering with AI as co-founder and employees. It replaces traditional teams, heavy capital, and multi-year roadmaps with hybrid human-AI intelligence and rapid proof cycles."
-  - question: "How can one person compete with teams?"
-    answer: "AI provides analysis, pattern recognition, and execution support; you provide strategy, relationships, and final decisions. Combined with 12-week experiments and proactive agents, one operator can run multiple ventures in parallel. See our Post-Human Entrepreneur manifesto."
-  - question: "What's the difference between solo and post-human?"
-    answer: "Solo means you do everything yourself. Post-human means you and AI form a hybrid unit: AI handles what it's best at (speed, breadth, objectivity), you handle vision, judgment, and execution. The output is portfolio-scale without a traditional team."
+  - question: "What is one-developer expedition building?"
+    answer: "Walking unnamed roads as a single operator: AI carries repetitive pack weight (research, drafts, routine execution); the human holds the compass (strategy, relationships, Approve gates). The map is full — this is terrain traditional teams skip, not a claim to replace every team everywhere."
+  - question: "How can one developer cover ground that used to take a team?"
+    answer: "AI automation handles breadth and speed inside policy; you provide judgment and final decisions. Measured experiments and human Approve before publish keep quality honest. See Field Notes for receipts, not manifestos."
+  - question: "What's the difference between solo and expedition studio?"
+    answer: "Solo often means doing everything yourself. Expedition studio means one developer + AI pack-carriers on bounded routes — compass stays human, external send stays gated. Portfolio status labels (Focus, Monitor, Parked) are operational taxonomy, not brand theater."
 ---
 
-# Post-Human Entrepreneurship
+# One-Developer Expedition
 
-**Pillar Page** | Part of our [AI-Native Venture Building](/insights) topical authority
+**Pillar Page** | Part of our [Insights](/insights) archive — reframed from earlier post-human framing
 
-This pillar explains WHY the old model is broken and positions this site at the forefront of a new movement. It captures high-intent searches from builders questioning traditional approaches.
+This pillar captures searches from builders asking how one operator ships without a traditional team. The honest answer: **expedition, not agency** — AI carries; you steer.
 
 ## Core Concept
 
-The rules have changed overnight. A single individual, properly partnered with AI, now possesses capabilities that would have required armies just months ago. This is the philosophical and strategic foundation of AI-native building.
+The map is full. Named roads are crowded. Unnamed roads still exist — and one developer with AI automation can walk them when the compass stays human and Approve gates stay real.
+
+This is not autonomy theater. It is not "AI as CEO." It is measured terrain-walking with receipts in [Field Notes](/posts/).
 
 ## Key Topics Covered
 
-### The Paradigm Shift
-- The death of traditional startup infrastructure
-- Teams as liability, not assets
-- Capital requirements collapse
-- Geographic barriers elimination
-- Expertise democratization through AI
+### Expedition vs agency
+- One developer, bounded routes — not infinite parallel "agent teams"
+- AI carries pack weight; human holds compass and Approve
+- Field Notes as receipts, not manifestos
+- Honest portfolio status (Focus · Monitor · Parked) without making taxonomy the hero
 
-### Hybrid Intelligence
-- Neural speed advantages
-- Infinite expertise on demand
-- Zero-capital creation
-- Global from day zero
-- The stealth advantage
+### What actually scales
+- Policy-bound automation on proven workflows
+- Human Approve before publish, deploy, external send
+- 12-week experiments with kill/pivot discipline
+- Cost-aware infrastructure (see [Stack](/stack))
 
-### The New Breed
-- AI-native entrepreneurs
-- Beyond human limitations
-- Single operator scaling
-- Future of venture creation
+### What we do not claim
+- Corporate-scale output as brand theater
+- Autonomous executives or fake C-suite agents
+- Replacing every team in every domain
 
 ## Featured Content
 
 ### Essential Reading
-- [The Post-Human Entrepreneur](/posts/the-post-human-entrepreneur) - Our foundational manifesto
-- [AI as Co-Founder](/posts/ai-as-cofounder) - The practical implementation of hybrid intelligence
+- [The Post-Human Entrepreneur](/posts/the-post-human-entrepreneur) — historical essay; read with expedition lens (archive)
+- [AI as Co-Founder](/posts/ai-as-cofounder) — historical essay; reframed operationally as compass/pack split (archive)
+- [How I Run 7 Sites With One Person and AI Agents](/posts/how-i-run-7-sites-with-one-person-and-ai-agents) — receipts from the road
 
 ### Related Pillars
-- [AI-Human Collaboration](/insights/ai-human-collaboration) - The methodology behind post-human building
-- [Venture Studio Operations](/insights/venture-studio-operations) - Scaling post-human operations
-- [AI-Native Products](/insights/ai-native-products) - Building post-human products
+- [AI-Human Collaboration](/insights/ai-human-collaboration) — compass and pack, not co-founder theater
+- [Venture Studio Operations](/insights/venture-studio-operations) — one-developer portfolio ops
+- [Focus · Monitor · Parked](/insights/focus-monitor-parked) — status taxonomy (operational, not brand hero)
 
 ## Common Questions Answered
 
 This pillar answers questions like:
-- What is post-human entrepreneurship?
-- How can one person compete with teams?
-- What's the difference between solo and post-human?
-- How do you scale without hiring?
-- What are the limits of AI-native building?
-- How do you maintain quality at AI speed?
-
-## Search Intent Coverage
-
-This pillar captures searches for:
-- "post-human entrepreneur"
-- "solo operator scaling"
-- "one person corporation"
-- "AI native business"
-- "single founder scaling"
-- "solo entrepreneur with AI"
-- "hybrid intelligence business"
-- "future of entrepreneurship"
+- How does one developer ship without a team?
+- What is expedition studio vs agency?
+- Where are the Approve gates?
+- What is honest vs theater in AI-native building?
 
 ---
 
-_This is a living document. As we publish new content on post-human entrepreneurship, it will be added here to maintain topical authority._
-
+_This pillar reframes earlier post-human positioning into expedition voice. Historical posts remain linked for useful history._

--- a/src/pages/insights/venture-studio-operations.mdx
+++ b/src/pages/insights/venture-studio-operations.mdx
@@ -1,97 +1,78 @@
 ---
 layout: '@/layouts/PageLayout.astro'
-title: Venture Studio Operations
-description: Operating AI-native venture studios. Portfolio management, parallel experiments, automation systems, and scalable venture creation.
+title: Expedition Studio Operations
+description: One-developer portfolio ops — honest status labels, measured experiments, human Approve gates. Expedition, not agency.
 faq:
-  - question: "How do you operate a venture studio alone?"
-    answer: "We use an operating system of playbooks, proactive AI agents, and self-healing pipelines. The Post-Human Venture Engine runs signal mesh (opportunity sourcing), assembly lines (research, code, content), and 12-week proof cycles. One operator approves and directs; agents execute and propose."
+  - question: "How do you operate an expedition studio alone?"
+    answer: "One developer holds the compass; AI automation carries pack weight on bounded routes. Portfolio status (Focus, Monitor, Parked, Avvecklat) stays honest on project cards. Publish, deploy, and external send require human Approve — see Field Notes for receipts."
   - question: "What's the difference between a venture studio and an accelerator?"
-    answer: "Accelerators take existing teams and mentor them. Venture studios build ventures in-house from idea to validation, often with shared infrastructure and methodology. Our studio is AI-native: we build with AI as co-founder and run multiple experiments in parallel with minimal headcount."
-  - question: "What metrics matter for venture studio experiments?"
-    answer: "We use weighted scores for problem validation, market demand, solution effectiveness, technical feasibility, and business model viability. Each experiment gets a scale/pivot/kill decision at the end of its 12-week cycle. Portfolio metrics include experiments shipped per quarter and learning capture from archived builds."
+    answer: "Accelerators mentor existing teams. Expedition studios walk product terrain with minimal headcount — measured experiments, not consulting intake. This studio is one developer + policy-bound automation, not an agency bench."
+  - question: "What metrics matter for expedition experiments?"
+    answer: "Falsifiable validation contracts, 12-week proof cycles, and honest kill/pivot decisions. Portfolio taxonomy tracks attention allocation; Field Notes capture outcomes. Status labels are operational truth, not brand hero lines."
 ---
 
-# Venture Studio Operations
+# Expedition Studio Operations
 
-**Pillar Page** | Part of our [AI-Native Venture Building](/insights) topical authority
+**Pillar Page** | Part of our [Insights](/insights) archive
 
-This pillar positions the site as the authority on AI-native studio operations, a unique and defensible position. Most venture studio content focuses on traditional studios—this covers the AI-native approach.
+Most studio content assumes traditional teams. This pillar covers **one-developer expedition ops**: walking multiple routes with AI pack-carriers and human Approve gates.
 
 ## Core Concept
 
-Venture studios are a growing model, but most operate with traditional infrastructure. This pillar covers how to operate a venture studio using AI-native methodology: managing portfolios, running parallel experiments, and scaling operations as a solo operator or small team.
+Expedition studio operations mean bounded attention, honest status on every project card, and receipts in Field Notes — not dashboard theater or fake executive agents.
 
 ## Key Topics Covered
 
-### Studio Structure & Operations
-- Venture studio vs traditional startup
-- Portfolio experiment management
-- Parallel venture building
-- Venture studio metrics
-- Scaling venture studio operations
+### Studio structure
+- One developer, many routes — with honest Focus · Monitor · Parked labels
+- Parallel experiments with kill discipline
+- Portfolio visibility without agency positioning
 
-### Automation & Systems
-- Venture studio automation systems
-- Signal mesh and opportunity sourcing
-- Assembly line workflows
-- Proof cycle implementation
-- Operating system for venture studios
+### Systems
+- Policy-bound automation on proven workflows
+- Approve before publish, deploy, external send
+- Stack and cost reference — [/stack/](/stack/)
 
-### Strategy & Execution
-- Venture studio team structure
-- Venture studio funding models
-- Deciding which ventures to pursue
-- Transitioning from experiment to real business
-- Exit strategies for studio ventures
+### Execution
+- Which routes get compass time
+- Transitioning experiment → product
+- Archive honesty (Avvecklat without brand hero blocks)
 
 ## Featured Content
 
-### Essential Projects
-- [The Unnamed Roads](/projects/anonymous-venture-studio) — Our experimental venture studio approach
-- [Post-Human Venture Engine](/projects/post-human-venture-engine) — The operating system behind portfolio-scale operations
+### Essential projects
+- [Projects in flight](/projects/) — honest status on every route
+- Field Notes receipts — [/posts/](/posts/)
 
-### Related Pillars
-- [Rapid Experimentation Frameworks](/insights/experimentation-frameworks) — The methodology for studio experiments
-- [Auto Agent Workflows](/insights/auto-agent-workflows) — How agents enable studio operations
-- [Post-Human Entrepreneurship](/insights/post-human-entrepreneurship) — The paradigm shift enabling solo studios
+### Related pillars
+- [Rapid Experimentation](/insights/experimentation-frameworks) — 12-week proof cycles
+- [Policy-Bound Agents](/insights/auto-agent-workflows) — Approve-gated automation
+- [One-Developer Expedition](/insights/post-human-entrepreneurship) — expedition framing
 
 ## Common Questions Answered
 
 This pillar answers questions like:
-- How do you operate a venture studio alone?
-- What's the difference between studio and accelerator?
-- How do you manage multiple ventures in parallel?
-- What automation systems do venture studios need?
-- How do you source opportunities for a studio?
-- What metrics matter for venture studios?
-- How do you decide which ventures to pursue?
-- What's the operating system for venture studios?
+- How does one developer run a portfolio?
+- What's expedition studio vs agency?
+- Where are Approve gates in daily ops?
+- How does Focus · Monitor · Parked allocate attention?
 
 ## Search Intent Coverage
 
 This pillar captures searches for:
-- "AI native venture studio"
-- "venture studio operations"
-- "portfolio venture building"
-- "venture studio methodology"
-- "parallel venture building"
-- "venture studio automation"
-- "solo venture studio"
+- "one developer venture studio"
+- "expedition studio operations"
+- "solo portfolio building"
+- "AI native studio operations"
 - "venture studio playbook"
 
-## The Difference: Studio vs Accelerator vs Fund
+## Studio vs accelerator vs fund
 
 Full comparison: [Agency vs venture studio vs incubator](/insights/agency-vs-venture-studio-vs-incubator).
 
-**Venture Studio**: Builds companies from scratch, owns significant equity, provides operational support.
-
-**Accelerator**: Provides mentorship and funding to existing startups, takes smaller equity.
-
-**Fund**: Provides capital only, takes equity, minimal operational involvement.
-
-AI-native studios can operate with dramatically lower overhead, enabling solo operators to manage portfolios that previously required teams. Portfolio attention uses [Focus · Monitor · Parked](/insights/focus-monitor-parked).
+Portfolio attention uses [Focus · Monitor · Parked](/insights/focus-monitor-parked) — operational taxonomy, not brand hero.
 
 ---
 
-_This is a living document. As we publish new content on venture studio operations, it will be added here to maintain topical authority._
+_This pillar reframes venture studio ops into expedition voice. Historical links preserved where useful._
 

--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -40,6 +40,15 @@ const frontmatter: PageLayoutProps['frontmatter'] = {
   <h1>
     {frontmatter.title}
   </h1>
+  {
+    page.currentPage === 1 && (
+      <p class="mb-8 max-w-2xl text-base leading-relaxed text-slate-300">
+        Dispatches from the road — receipts from building in public, not a
+        manifesto. Field Notes capture what shipped, what broke, and what it
+        cost.
+      </p>
+    )
+  }
   <PostsList posts={page.data} />
 
   <Pagination slot="bottom" page={page} />

--- a/src/theme.config.ts
+++ b/src/theme.config.ts
@@ -4,7 +4,7 @@ export default defineThemeConfig({
   site: 'https://www.theunnamedroads.com',
   title: 'The Unnamed Roads',
   description:
-    'AI-native venture studio building measured, decision-first companies. Portfolio of focused experiments, Field Notes for indie founders, and a Company OS that compounds learning.',
+    'Expedition studio — one developer, unnamed roads. AI carries the pack; human holds the compass. Field Notes receipts from building in public.',
   author: 'The Unnamed Roads',
   navbarItems: [
     { label: 'Projects', href: '/projects' },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements locked Brand Manager expedition positioning from #91 — **Expedition studio. The map is full. One developer. AI carries the pack; human holds the compass.**

Closes positioning drift away from Focus/3-bets/Approve-as-hero and AI-as-CEO theater.

## P0 changes

### Homepage hero
- Eyebrow → **Expedition studio**; H1 unchanged
- New subcopy + support line per locked copy
- CTAs: **Read Field Notes** (primary) · **See what's in flight** → `/projects/`
- Removed learning-loop panel from above-the-fold hero
- Removed Company OS Avvecklat brand block from homepage (data retained in `structure.json` for reference)

### Meta
- Title → `The Unnamed Roads | One developer. Unnamed roads.`
- Description reframed to map-full / one developer / Field Notes receipts — no Approve Gates / 3 Focus bets in SERP hero

### About
- Lede → Stockholm · one developer · roads the map doesn't name · AI carries · Approve before anything leaves camp
- Focus · Monitor · Parked taxonomy demoted below fold

### Field Notes (`/posts/`)
- Intro lede: dispatches from the road; receipts; not manifesto

### Insights
- Reframed pillar pages + index cards from co-founder/post-human/autonomous-agent theater → expedition voice (history preserved, not deleted)

## Files changed

| File | Change |
|------|--------|
| `src/content/homepage/structure.json` | Hero copy, CTAs, Field Notes teaser |
| `src/components/HomepageShell.astro` | Hero render, remove loop panel + Company OS section |
| `src/pages/index.mdx` | Meta title/description + FAQ |
| `src/theme.config.ts` | Site default description |
| `src/pages/about.mdx` | Lede + section reorder |
| `src/pages/posts/[...page].astro` | Page-1 intro lede |
| `src/pages/insights.astro` | Index hero + pillar card copy |
| `src/pages/insights/post-human-entrepreneurship.mdx` | Reframe → One-Developer Expedition |
| `src/pages/insights/ai-human-collaboration.mdx` | Reframe → Compass & Pack |
| `src/pages/insights/auto-agent-workflows.mdx` | Reframe → Policy-Bound Agents |
| `src/pages/insights/venture-studio-operations.mdx` | Reframe → Expedition Studio Operations |

## Judgment calls

- **Kept** Focus/Monitor/Parked/Avvecklat on project cards and ventures status policy — portfolio honesty taxonomy, not brand hero
- **Removed** homepage Company OS section entirely rather than demoting to footer — cleanest cut of Avvecklat as brand block; essay still linked from About/Insights
- **Reframed** insights pillars in place rather than noindex — preserves useful history and URLs while updating expedition voice in frontmatter + lede
- **Left** historical Field Note posts (`ai-as-cofounder`, `the-post-human-entrepreneur`) untouched — linked from reframed pillars as archive
- **Operating system** daily pipeline section remains on homepage but below ventures + Field Notes teaser (below fold)

## Verification

- `pnpm check` ✅ (lint + astro check)
- `pnpm build` ✅
- curl verification of live preview HTML for hero, meta title, about lede, posts lede, insights cards

## KEEP (unchanged)

- Human Approve as operational truth (FAQ, /agents/, operating pipeline copy)
- Anti-consulting Contact
- Portfolio status honesty on project cards
- Spelling Emil Ingemar Karlsson

Fixes #91
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c29167fd-69fc-42cb-b6de-83f5d65a56a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c29167fd-69fc-42cb-b6de-83f5d65a56a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

