### PR TITLE
[Brand] EN portfolio list: English labels, full 8-set visible, honest status

### DIFF
--- a/src/content/homepage/structure.json
+++ b/src/content/homepage/structure.json
@@ -86,8 +86,8 @@
           "detail": "Dormant — not shown as Active."
         },
         {
-          "id": "avvecklat",
-          "label": "Avvecklat",
+          "id": "wound-down",
+          "label": "Wound down",
           "detail": "Wound down — kept as reference, not an active product."
         }
       ]
@@ -198,9 +198,9 @@
   },
   "companyOs": {
     "eyebrow": "Archive · TUR Company OS",
-    "title": "Operating model reference — platform Avvecklat",
+    "title": "Operating model reference — platform wound down",
     "description": "Company OS was the studio control plane for portfolio hierarchy, approval gates and learning loops. The platform wound down in September 2026; the decision-first playbook and human Approve gates remain how we ship.",
-    "statusNote": "Avvecklat September 2026 — kept as reference, not an active product.",
+    "statusNote": "Wound down September 2026 — kept as reference, not an active product.",
     "primaryCta": {
       "label": "Read the operating system essay",
       "href": "/insights/ai-native-venture-studio-operating-system"

--- a/src/content/projects/bebischecklistan.md
+++ b/src/content/projects/bebischecklistan.md
@@ -1,6 +1,6 @@
 ---
-title: Bebischecklistan
-description: Checklistor och förberedelser inför bebis — ett Monitor-koncept i TUR Family.
+title: Baby Checklist
+description: Nesting checklists and preparation flows for expecting parents — a parked concept in the TUR Family cluster.
 url: https://tur-nesting.vercel.app
 startDate: 2025-08-01
 tags:
@@ -24,7 +24,7 @@ homepage:
   href: https://tur-nesting.vercel.app
 ---
 
-# Bebischecklistan
+# Baby Checklist
 
-Nesting checklists and preparation flows for expecting parents. Monitor-only in
-the Growth Operating Loop until a separate validation contract is approved.
+Nesting checklists and preparation flows for expecting parents. Parked in the
+portfolio until a separate validation contract is approved — adjacent to Parental Leave Planner, not a parallel Family cluster bet.

--- a/src/content/projects/parental-leave-planner.md
+++ b/src/content/projects/parental-leave-planner.md
@@ -1,6 +1,6 @@
 ---
-title: Föräldraledighetsplaneraren
-description: Gratis planering av svensk föräldraledighet — dagar, ekonomi och scenarier synliga innan familjen bestämmer sig.
+title: Parental Leave Planner
+description: Free Swedish parental leave planning — days, pay and trade-offs visible before the family commits.
 url: https://tur-parentalleave.vercel.app
 startDate: 2025-06-01
 tags:
@@ -25,8 +25,8 @@ homepage:
   tag: Family
   href: https://tur-parentalleave.vercel.app
 faq:
-  - question: "What is Föräldraledighetsplaneraren?"
-    answer: "A free Swedish parental leave planner — model days, income and scenarios before the family commits. Built for phone review and assistant handoff, not spreadsheet archaeology."
+  - question: "What is Parental Leave Planner?"
+    answer: "A free Swedish parental leave planner (Föräldraledighetsplaneraren in Swedish) — model days, income and scenarios before the family commits. Built for phone review and assistant handoff, not spreadsheet archaeology."
   - question: "Who is it for?"
     answer: "Expecting parents and guardians in Sweden who need föräldrapenning, delning and ekonomi visible without reading the full rulebook."
   - question: "How do you decide what to build next?"
@@ -35,9 +35,9 @@ faq:
     answer: "Status Focus — production consumer product with organic search evidence and shareable plan completions. Partner surfaces stay GDPR-aware; no fake user counts."
 ---
 
-# Föräldraledighetsplaneraren
+# Parental Leave Planner
 
-**Planera er föräldraledighet med lugn och klarhet.**
+**Plan Swedish parental leave with clarity — days, pay and trade-offs before you commit.**
 
 A production consumer product in the TUR Family cluster. Parents model days,
 income and scenarios without needing to become experts in the rulebook.

--- a/src/content/projects/the-print-route.md
+++ b/src/content/projects/the-print-route.md
@@ -12,7 +12,7 @@ tags:
   - logistics
   - gdpr
 homepage:
-  featured: false
+  featured: true
   order: 10
   statusLabel: Parked
   statusTone: exploring

--- a/src/content/projects/tur-company-os.md
+++ b/src/content/projects/tur-company-os.md
@@ -11,7 +11,7 @@ tags:
 homepage:
   featured: false
   order: 3
-  statusLabel: Avvecklat
+  statusLabel: Wound down
   statusTone: exploring
   statusDotColor: bg-slate-500
   animateDot: false
@@ -20,12 +20,12 @@ homepage:
   summary: >-
     Portfolio control plane discontinued. The explainer and Field Notes remain as archive; no active platform development.
   metricLabel: Mode
-  metricValue: Avvecklat
+  metricValue: Wound down
   tag: Studio
 ---
 
 # TUR Company OS
 
-Former control plane for The Unnamed Roads. The platform is **avvecklat** (wound down) as of September 2026.
+Former control plane for The Unnamed Roads. The platform is **wound down** as of September 2026.
 
 The [operating system explainer](/insights/ai-native-venture-studio-operating-system) and this project page stay published as reference — the studio now runs a bounded Focus set without an active Company OS product surface.

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -10,7 +10,7 @@ faq:
   - question: "Do agents publish or send outbound autonomously?"
     answer: "No. Agents draft and research inside policy. Publish, deploy and external send require explicit human Approve — typically on phone, not in meetings."
   - question: "What does Focus mean in the portfolio?"
-    answer: "Focus is internal portfolio taxonomy — active validation contracts on a bounded set of product bets. Status labels (Focus, Monitor, Parked, Avvecklat) stay honest on project cards; they are not the brand story. See Focus · Monitor · Parked for the full policy."
+    answer: "Focus is internal portfolio taxonomy — active validation contracts on a bounded set of product bets. Status labels (Focus, Monitor, Parked, Wound down) stay honest on project cards; they are not the brand story. See Focus · Monitor · Parked for the full policy."
   - question: "Is this an agency or AI-autonomy theater?"
     answer: "Neither. Expedition, not agency — one developer with AI automation, human Approve gates, and Field Notes as receipts. No fake executive team; see /agents/ for how workflow roles are described."
 ---
@@ -32,7 +32,7 @@ import HomepageShell from '@/components/HomepageShell.astro'
     </div>
     <div>
       <dt class="font-semibold text-white">What does Focus mean in the portfolio?</dt>
-      <dd class="mt-1 text-slate-300">Focus is internal portfolio taxonomy — active validation contracts on a bounded set of product bets. Status labels (Focus, Monitor, Parked, Avvecklat) stay honest on project cards; they are not the brand story. See <a class="text-accent underline" href="/insights/focus-monitor-parked">Focus · Monitor · Parked</a>.</dd>
+      <dd class="mt-1 text-slate-300">Focus is internal portfolio taxonomy — active validation contracts on a bounded set of product bets. Status labels (Focus, Monitor, Parked, Wound down) stay honest on project cards; they are not the brand story. See <a class="text-accent underline" href="/insights/focus-monitor-parked">Focus · Monitor · Parked</a>.</dd>
     </div>
     <div>
       <dt class="font-semibold text-white">Is this an agency or AI-autonomy theater?</dt>

--- a/src/util/status.ts
+++ b/src/util/status.ts
@@ -13,6 +13,7 @@ const LABEL_VARIANTS: Record<string, StatusVariant> = {
   monitor: 'monitor',
   parked: 'parked',
   avvecklat: 'avvecklat',
+  'wound down': 'avvecklat',
   concept: 'concept',
   personal: 'personal',
   linked: 'linked',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #96

## Din tur

Review portfolio cards on `/` and `/projects/` — legend should read **Wound down** (not Avvecklat), Parental Leave Planner and Baby Checklist titles/descriptions in English, and all eight SEO/dev surfaces visible on the homepage (Print Route with Parked badge).

## Changes

- **Status legend:** `Avvecklat` → **Wound down** in `structure.json` status policy and homepage FAQ (`index.mdx`)
- **Parental Leave Planner:** English title, description, and H1 in `parental-leave-planner.md` (Swedish product name kept only in FAQ parenthetical)
- **Baby Checklist:** Translated title, description, and body in `bebischecklistan.md`
- **TUR Company OS:** `statusLabel` / `metricValue` → **Wound down**; body copy uses English primary label
- **The Print Route:** `featured: true` so the 8-set surface appears on homepage with Parked badge
- **status.ts:** Map `Wound down` label to existing `avvecklat` chip variant for styling

Focus membership unchanged (FLP + THA + TUR remain Focus).

## Verification

- `pnpm check` — green (eslint, stylelint, astro check: 0 errors)
- `pnpm build` — success
- Built HTML checks:
  - Homepage legend shows **Wound down**; no user-facing **Avvecklat**
  - Homepage cards include all 8-set: EIK (Linked), TUR/THA/FLP (Focus), Brain/Agent Fabric/TAN/AAF (Monitor), Print Route (Parked)
  - `/projects` shows **Parental Leave Planner**, **Baby Checklist**, **Wound down** on TUR Company OS

## Learnings

- Homepage venture cards are driven by `homepage.featured` on project content files, not only `structure.json` fallback — Print Route needed `featured: true` in content, not just the JSON catalog.
- `resolveStatusVariant()` needed an explicit `'wound down'` key so renamed labels keep the slate chip styling previously tied to `avvecklat`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f668b67-5db0-4c86-8565-5a1c5f308525?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f668b67-5db0-4c86-8565-5a1c5f308525&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

