### PR TITLE
docs: OpenHands compatibility for agent label loop

### DIFF
--- a/.openhands/README.md
+++ b/.openhands/README.md
@@ -1,0 +1,10 @@
+# OpenHands — this repository
+
+**Primary agent instructions:** [`../AGENTS.md`](../AGENTS.md)
+
+**Label-loop executor (OpenHands):** [`../docs/agent-setup/OPENHANDS.md`](../docs/agent-setup/OPENHANDS.md)
+
+Cursor automations and prompts remain under `docs/agent-setup/` (EXECUTE_PROMPT, LEARN_PROMPT) — do not duplicate here.
+
+**INSTALL:** `corepack enable && pnpm install --frozen-lockfile`  
+**VERIFY:** `pnpm check`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,19 +28,21 @@ Source label: `Contact Form - The Unnamed Roads`.
 Cross-portfolio hosting map: `tur-automations/docs/HOSTING-VERCEL.md`.
 Monitoring/contact ops: `tur-automations/docs/MONITORING-SYNTHETIC.md`.
 
-## Agent loop (Cursor Cloud Automations)
+## Agent loop (Cursor Cloud Automations or OpenHands)
 
 Semi-automatic 24/7 Execute + Learn loop. **Human merge only** — no auto-merge.
 
+Same GitHub labels (`agent:draft` → `agent:ready` → …) work with **Cursor Cloud Automations** (primary) or **OpenHands** as an alternate executor — see [`docs/agent-setup/OPENHANDS.md`](docs/agent-setup/OPENHANDS.md).
+
 | | |
 |--|--|
-| Install (Cloud Agent) | `corepack enable && pnpm install --frozen-lockfile` |
+| Install | `corepack enable && pnpm install --frozen-lockfile` |
 | Verify before PR | `pnpm check` |
 | Build when needed | `pnpm build` |
 | Default branch | `main` |
 | Human inbox | https://github.com/pulls/assigned |
-| Docs | `docs/agent-setup/` (EXECUTE_PROMPT, LEARN_PROMPT, APPROVE, PORTABLE_PLAYBOOK) |
+| Docs | `docs/agent-setup/` (EXECUTE_PROMPT, LEARN_PROMPT, APPROVE, PORTABLE_PLAYBOOK, OPENHANDS) |
 | Issue template | `.github/ISSUE_TEMPLATE/agent-task.yml` → start `agent:draft`, flip to `agent:ready` |
 
-Runtime: Astro 5 static; pnpm 9 via corepack; Vercel deploy on push to `main`. Cloud Agent environment: `.cursor/environment.json`.
+Runtime: Astro 5 static; pnpm 9 via corepack; Vercel deploy on push to `main`. Cursor Cloud Agent environment: `.cursor/environment.json`. OpenHands stub: `.openhands/` → this file.
 

--- a/docs/agent-setup/OPENHANDS.md
+++ b/docs/agent-setup/OPENHANDS.md
@@ -1,0 +1,70 @@
+# OpenHands executor (alternate to Cursor Cloud Automations)
+
+OpenHands can run the **same GitHub label loop** as Cursor Execute — one `agent:ready` issue at a time, branch, verify, PR, human merge. Cursor-specific prompts and automations stay in [EXECUTE_PROMPT.md](./EXECUTE_PROMPT.md) and [LEARN_PROMPT.md](./LEARN_PROMPT.md); this file is the OpenHands-facing slice only.
+
+---
+
+## Loop (shared with Cursor)
+
+```text
+agent:draft → agent:ready → agent:running → PR → human merge → agent:done
+```
+
+| Rule | Detail |
+|------|--------|
+| Claim | **One** open issue with `agent:ready` per run. Ignore `agent:running` / `agent:done`. |
+| Sort | `[qNN]` prefix in title (lowest N first); else oldest `created_at`. |
+| Labels | On claim: add `agent:running`, remove `agent:ready`. On PR: set `agent:done`. |
+| PR | Branch `cursor/agent-issue-<number>`, link issue (`Closes #<number>`). |
+| Merge | **Never auto-merge.** Human approves via [Review requests](https://github.com/pulls/review-requested) / [Assigned](https://github.com/pulls/assigned). |
+| Inbox | Mark PR ready (not draft), assign + request review from `emilingemarkarlsson`. |
+
+Full playbook: [PORTABLE_PLAYBOOK.md](./PORTABLE_PLAYBOOK.md). Human approve habit: [APPROVE.md](./APPROVE.md).
+
+---
+
+## Install & verify (this repo)
+
+| Step | Command |
+|------|---------|
+| **INSTALL** | `corepack enable && pnpm install --frozen-lockfile` |
+| **VERIFY** | `pnpm check` |
+| Build (when acceptance requires) | `pnpm build` |
+
+Repo rules and hosting: root [`AGENTS.md`](../../AGENTS.md). Standing constraints: `.cursor/rules/always-on.mdc` (apply even when not using Cursor UI).
+
+---
+
+## What OpenHands should read
+
+1. Issue acceptance criteria
+2. [`AGENTS.md`](../../AGENTS.md)
+3. Relevant `.cursor/rules/` and `.cursor/skills/` (same as Cursor Execute)
+4. This file for executor-specific install/verify and inbox routing
+
+Do **not** duplicate or replace [EXECUTE_PROMPT.md](./EXECUTE_PROMPT.md) — paste that prompt only into Cursor Automations.
+
+---
+
+## Suggested OpenHands task prompt (paste into your OpenHands job)
+
+```
+Pick ONE open issue labeled agent:ready in this repo (lowest [qNN] title prefix, else oldest).
+
+1. Set agent:running, remove agent:ready
+2. Read acceptance criteria; read AGENTS.md and docs/agent-setup/OPENHANDS.md
+3. Minimal implementation only
+4. INSTALL: corepack enable && pnpm install --frozen-lockfile
+5. VERIFY: pnpm check (pnpm build if acceptance requires)
+6. Push branch cursor/agent-issue-<number>; open PR (Closes #<number>)
+7. Ready for review; assign + request review: emilingemarkarlsson
+8. Set agent:done on the issue
+
+Never merge. Max 2 retries; if blocked: agent:needs-human + comment why.
+```
+
+---
+
+## `.openhands/` stub
+
+Project-level OpenHands customization lives in [`.openhands/`](../../.openhands/) and points at root [`AGENTS.md`](../../AGENTS.md). Optional `setup.sh` / Stop hooks can wrap the same INSTALL/VERIFY commands above; see [OpenHands repository customization](https://docs.openhands.dev/openhands/usage/customization/repository).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds OpenHands as an alternate executor of the same GitHub agent label loop without rewriting Cursor-specific agent-setup docs.

## Changes

- **`docs/agent-setup/OPENHANDS.md`** — OpenHands-facing slice: one `agent:ready` at a time, PR + human merge, INSTALL/VERIFY commands, suggested task prompt; points at existing EXECUTE/LEARN/PORTABLE docs.
- **`AGENTS.md`** — Notes OpenHands alongside Cursor Cloud Automations; links OPENHANDS.md and `.openhands/` stub.
- **`.openhands/README.md`** — Minimal stub pointing at root `AGENTS.md` and OPENHANDS.md.

## Verification

```bash
corepack enable && pnpm install --frozen-lockfile
pnpm check
```

Result: 0 errors, 0 warnings.

## Notes

- Does not modify `EXECUTE_PROMPT.md`, `LEARN_PROMPT.md`, or other Cursor automation prompts.
- Human merge only — do not auto-merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23d0e17c-e1b6-437a-877e-505dd41b2a77?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23d0e17c-e1b6-437a-877e-505dd41b2a77&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

