### PR TITLE
fix(agent-fabric): Vercel URL as canonical public site

### DIFF
--- a/src/content/homepage/structure.json
+++ b/src/content/homepage/structure.json
@@ -144,12 +144,12 @@
         "id": "taf",
         "name": "THE AGENT FABRIC",
         "focus": "Distributed agent infrastructure for enterprise AI",
-        "summary": "B2B surface on sovereign AI and edge nodes — in the SEO/dev attention set. Canonical domain recovering; preview live on Vercel.",
+        "summary": "B2B surface on sovereign AI and edge nodes — in the SEO/dev attention set. Canonical URL is the Vercel deployment; theagentfabric.com apex is unregistered.",
         "tag": "saas",
         "status": { "label": "Monitor", "tone": "active" },
-        "metric": { "label": "Site", "value": "Canonical recovering" },
+        "metric": { "label": "Site", "value": "Live on Vercel" },
         "href": "https://tur-theagentfabric.vercel.app/",
-        "ctaLabel": "Open preview"
+        "ctaLabel": "Open site"
       },
       {
         "id": "tan",

--- a/src/content/projects/the-agent-fabric.md
+++ b/src/content/projects/the-agent-fabric.md
@@ -1,8 +1,8 @@
 ---
 title: The Agent Fabric
-description: Distributed agent infrastructure for enterprise AI — sovereign, edge-ready agent runtime and orchestration narrative. Preview live while theagentfabric.com recovers.
+description: Distributed agent infrastructure for enterprise AI — sovereign, edge-ready agent runtime and orchestration narrative. Live on tur-theagentfabric.vercel.app; theagentfabric.com apex unregistered.
 url: https://tur-theagentfabric.vercel.app/
-canonicalUrl: https://theagentfabric.com
+canonicalUrl: https://tur-theagentfabric.vercel.app/
 startDate: 2024-12-01
 tags:
   - enterprise-ai
@@ -20,17 +20,17 @@ homepage:
   focus: >-
     Distributed agent infrastructure for enterprise AI
   summary: >-
-    B2B surface on sovereign AI, edge nodes, and agent runtime — in the SEO/dev attention set. Canonical domain recovering; Vercel preview live.
+    B2B surface on sovereign AI, edge nodes, and agent runtime — in the SEO/dev attention set. Canonical URL is the Vercel deployment; theagentfabric.com apex is unregistered.
   metricLabel: Site
-  metricValue: Canonical recovering
+  metricValue: Live on Vercel
   tag: SaaS
   href: https://tur-theagentfabric.vercel.app/
-  ctaLabel: Open preview
+  ctaLabel: Open site
 ---
 
 # The Agent Fabric
 
-**Status:** Monitor · **Site:** theagentfabric.com recovering — [Vercel preview](https://tur-theagentfabric.vercel.app/) live
+**Status:** Monitor · **Canonical URL:** [tur-theagentfabric.vercel.app](https://tur-theagentfabric.vercel.app/) (theagentfabric.com apex unregistered)
 
 **Orchestrating distributed intelligence across data centers, edge nodes, and IoT devices.**
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Summarize the proposed changes**

Updates The Agent Fabric portfolio card and project page so the live canonical URL is `https://tur-theagentfabric.vercel.app/` per Emil's 2026-09-08 decision to skip buying `theagentfabric.com`. Copy is honest that the apex domain is unregistered. Monitor status unchanged.

**What is the type of change? Select one or more.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe)

**Is there any action needed after merging?**
None — content-only update.

**Please make sure the PR complies with this checklist**
- [x] The change has been tested locally
- [x] The code has been linted and type-checked
- [x] All relevant tests have been run and passed
- [x] There is currently no merge conflict
- [x] No new warnings or errors have appeared (if intended, please describe)

**Additional context**

- `src/content/projects/the-agent-fabric.md`: `canonicalUrl`, homepage metric/CTA, description, and on-page Site line
- `src/content/homepage/structure.json`: matching homepage portfolio card
- `pnpm check` passed (eslint, stylelint, astro check — 0 errors)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06fe89dc-25db-49e4-a32e-05f17d5bf6ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06fe89dc-25db-49e4-a32e-05f17d5bf6ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

