### PR TITLE
fix(seo): enforce trailing-slash 301 via Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "trailingSlash": true,
   "redirects": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Supersedes #130 (dirty after Site Audit merges).

Closes #107

Adds `"trailingSlash": true` to `vercel.json` on current main (keeps security headers + redirects).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Vercel routing/SEO flag; no application logic, auth, or data changes.
> 
> **Overview**
> Adds **`"trailingSlash": true`** to `vercel.json` so Vercel serves and redirects URLs with a trailing slash, aligning deployment behavior with Astro’s existing `trailingSlash: 'always'` setting.
> 
> This should normalize slash-duplicate URLs for SEO (e.g. in Search Console) via **301 redirects** without changing the existing host redirects or security/CORS headers in the same file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac5a14b0ce990fbf7efde7add7c53a5bc365f09e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->