### PR TITLE
docs(agent): clarify OpenHands ROI operating rule

### DIFF
--- a/docs/agent-setup/OPENHANDS.md
+++ b/docs/agent-setup/OPENHANDS.md
@@ -1,3 +1,9 @@
+## Operating rule (ROI)
+- Trigger: label `openhands` or `@openhands` → OpenHands runs with **Default LLM** (DeepSeek flash).
+- `task:easy-lite|easy|medium` = difficulty hints only (no auto model switch today).).
+- `task:hard` or fail×2 → use **Cursor PRO**, not OpenHands.
+- No `openhands` label = no agent spend.
+
 # OpenHands executor (alternate to Cursor Cloud Automations)
 
 OpenHands can run the **same GitHub label loop** as Cursor Execute — one `agent:ready` issue at a time, branch, verify, PR, human merge. Cursor-specific prompts and automations stay in [EXECUTE_PROMPT.md](./EXECUTE_PROMPT.md) and [LEARN_PROMPT.md](./LEARN_PROMPT.md); this file is the OpenHands-facing slice only.


### PR DESCRIPTION
Added operating rules for OpenHands execution and task difficulty hints.

**Summarize the proposed changes**
Please include a summary of the submitted changes. Explain their purpose or reference which issue is fixed. Please also include relevant motivation and context. List all added/removed/updated dependencies included in this change.

**What is the type of change? Select one or more.**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe)

**Is there any action needed after merging?**
Please give a quick overview of required actions after adding the new changes, such as updating documentation, adding new tests, or other, if there are any.

**Please make sure the PR complies with this checklist**
- [ ] The change has been tested locally
- [ ] The code has been linted and type-checked
- [ ] All relevant tests have been run and passed
- [ ] There is currently no merge conflict
- [ ] No new warnings or errors have appeared (if intended, please describe)

**Additional context**
Add any other context about the pull request here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent workflow guidance; no runtime or application code affected.
> 
> **Overview**
> Adds a new **Operating rule (ROI)** section at the top of `OPENHANDS.md` so teams know when OpenHands runs vs when to skip agent spend.
> 
> OpenHands is triggered only by the `openhands` label or `@openhands`, and uses the **Default LLM** (DeepSeek flash). Labels like `task:easy-lite`, `task:easy`, and `task:medium` are documented as difficulty hints only (no automatic model switch). **`task:hard`** or **two failures** should route work to **Cursor PRO** instead of OpenHands. Issues without the `openhands` label should not incur OpenHands usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c01e02fbd2e2af9272b7d36449eac4df0b7e3a17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->