### PR TITLE
docs(aeo): FAQPage GEO verification on home + Focus page (Closes #103)

### DIFF
--- a/docs/agent-runs/2026-09-11-faqpage-geo-103.md
+++ b/docs/agent-runs/2026-09-11-faqpage-geo-103.md
@@ -1,0 +1,51 @@
+# FAQPage GEO verification — home + one Focus page (#103)
+
+**Date:** 2026-09-11
+
+**Issue:** [#103](https://github.com/emilingemarkarlsson/theunnamedroads/issues/103) — AEO FAQPage schema on home + one Focus page (GEO), schema-only (brand FAQ copy owned by #100).
+
+The FAQPage builder and content already shipped via earlier PRs (#15 homepage FAQ, #77 THA/parental-leave FAQPage, #140 always-on rule, #147 project JSON-LD). This issue was the GEO verification close: confirm FAQPage JSON-LD is emitted and valid wherever FAQ content is visible, with no hire/fit-call schema.
+
+## Scope note
+
+- Schema-only — no brand FAQ copy rewritten; #100 still owns the copy.
+- Fence respected: TUR ≠ EIK ≠ THA.
+
+## Installed & verified
+
+| Step | Command | Result |
+|------|---------|--------|
+| INSTALL | `corepack enable && pnpm install --frozen-lockfile` | ok (pnpm 9.12.2) |
+| VERIFY | `pnpm check` | 0 errors / 0 warnings / 0 hints |
+| BUILD | `pnpm build` | ok (182 pages indexed) |
+
+## FAQPage JSON-LD — live + built output
+
+`https://www.theunnamedroads.com/` (home):
+- FAQPage present in single `application/ld+json` script; 4 Question nodes, each with `acceptedAnswer` (`Answer`/`text`).
+- Visible FAQ section: `<h2 id="home-faq">Common questions</h2>` + `<dl>` rendered.
+- Q&A: What is The Unnamed Roads? / Do agents publish or send outbound autonomously? / What does Focus mean in the portfolio? / Is this an agency or AI-autonomy theater?
+
+`https://www.theunnamedroads.com/projects/the-hockey-analytics/` (Focus):
+- FAQPage present; 4 Question nodes with `acceptedAnswer` (`Answer`/`text`).
+- Visible FAQ section: `<h2 id="project-faq">Common questions</h2>` + `<dl>` rendered.
+- Q&A mirror the validation-contract language (Focus — Club Pack beta; explicit human Approve gate; no fake traction).
+
+Bonus (unchanged, same pattern): `/projects/parental-leave-planner/` (Focus) also emits FAQPage with visible FAQ.
+
+## Schema lint (structural, on built HTML)
+
+For `dist/index.html` and `dist/projects/the-hockey-analytics/index.html`, and live equivalents:
+
+- `FAQPage` node present in graph with non-empty `mainEntity` array.
+- Every `mainEntity` item is `Question` with non-empty `name`.
+- Every `acceptedAnswer` is `Answer` with non-empty `text` (≥ 30 chars).
+- Results: **no errors** on either page.
+
+## No hire/fit-call schema
+
+No `Service` schema is emitted on the home page or project pages (no `service:` frontmatter in use anywhere); project nodes are `SoftwareApplication` + FAQPage only.
+
+## Rich Results / GSC
+
+FAQPage rich results are deprecated by Google outside health/authority verticals — no GSC validation is expected. GEO/AEO value here is LLM extractability of visible Q&A pairs, which the JSON-LD above confirms.


### PR DESCRIPTION
Closes #103

## Din tur

Vercel Preview URL: https://www.theunnamedroads.com/ (docs-only change; no preview deployment needed — schema verified on live + local build)

Efter merge: ta bort dig som assignee (GitHub nollställer den inte).

## Vad som ändrades

The FAQPage JSON-LD builder, config schema and FAQ content already ship on `main` via earlier AEO PRs (`#15` homepage FAQ, `#77` THA/parental-leave FAQPage, `#140` always-on rule, `#147` project JSON-LD). This PR is the **GEO verification close** for #103: schema-only, no brand FAQ copy rewritten (copy owned by #100).

- Adds `docs/agent-runs/2026-09-11-faqpage-geo-103.md` logging the verification of valid FAQPage JSON-LD on the homepage and one Focus project page (`/projects/the-hockey-analytics/`), with visible FAQ sections, no hire/fit-call (`Service`) schema, and `pnpm check` green.

## Verifiering

- **Homepage** (`/`): FAQPage in single `application/ld+json` graph — 4 Question nodes each with `acceptedAnswer` (`Answer`/`text`); visible `<h2 id="home-faq">Common questions</h2>` rendered. Verified **live** + built `dist/index.html`.
- **Focus page** (`/projects/the-hockey-analytics/`): FAQPage — 4 Question/acceptedAnswer pairs mirroring the validation-contract language (Focus — Club Pack beta, explicit human Approve gate); visible `<h2 id="project-faq">Common questions</h2>`. Verified **live** + built.
- **Schema lint** (structural, on built HTML): non-empty `mainEntity`; every item `Question` with non-empty `name`; every `acceptedAnswer` an `Answer` with non-empty `text` — **0 errors** on both pages.
- **No hire/fit-call schema**: no `Service` node emitted; project nodes are `SoftwareApplication` + FAQPage only.
- Bonus (unchanged): `/projects/parental-leave-planner/` (Focus) also emits FAQPage with visible FAQ.
- `pnpm check`: 0 errors / 0 warnings / 0 hints. `pnpm build`: ok.
- Note: Google deprecated FAQPage rich results outside health/authority verticals; value here is GEO/AEO LLM extractability of visible Q&A pairs.

## Learnings

- Homepage + Focus wedge FAQPage needs only frontmatter `faq` + a visible `<dl>` — `BaseLayout` emits the JSON-LD; never duplicate inline `<script type="application/ld+json">` FAQPage blocks (already an always-on rule).
- Verify GEO schema with `curl` + JSON parse on **live** AND built output before closing an AEO issue — catches "schema exists but page noindexed/hidden" gaps.

## Checklist

- [x] The change has been tested locally
- [x] The code has been linted and type-checked (`pnpm check`)
- [x] All relevant tests have been run and passed
- [x] There is currently no merge conflict
- [x] No new warnings or errors have appeared

## Additional context

Docs-only change (run note under `docs/agent-runs/`, repo convention for verification rituals). Never merge — Emil approves via https://github.com/pulls/assigned.

@emilingemarkarlsson can click here to [continue refining the PR](https://app.all-hands.dev/conversations/995ce86b-55dd-4274-a90b-8abf119e0d43)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition under existing `docs/agent-runs/` convention; no application or schema code changes.
> 
> **Overview**
> **Docs-only close for [#103](https://github.com/emilingemarkarlsson/theunnamedroads/issues/103):** adds `docs/agent-runs/2026-09-11-faqpage-geo-103.md`, recording that FAQPage JSON-LD (already on `main` from earlier AEO PRs) was verified on the homepage and Focus page `/projects/the-hockey-analytics/` — live and built HTML, structural schema lint with **0 errors**, visible FAQ sections, and **no** `Service` / hire-fit-call schema.
> 
> The note also logs `pnpm install`, `pnpm check`, and `pnpm build` results and clarifies scope: schema verification only; brand FAQ copy unchanged (#100); GEO value is LLM extractability, not GSC FAQ rich results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11bd0af833c533c4fb4f15410e23b6dbb2e6aaf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->