### PR TITLE
seo: internal links Field Notes ↔ Focus projects (Closes #78)

### DIFF
--- a/src/content/posts/12-week-experiment-framework.md
+++ b/src/content/posts/12-week-experiment-framework.md
@@ -10,7 +10,7 @@ draft: false
 
 > **Studio Field Note** — Our [experimentation frameworks](/insights/experimentation-frameworks) pillar in practice: 4 bets per year, phase gates, and documented kill criteria from anonymous product tests.
 
-After dozens of anonymous product bets, we standardized on a 12-week experimentation framework—long enough for signal, short enough to kill fast. This is the same method behind Focus projects at the studio.
+After dozens of anonymous product bets, we standardized on a 12-week experimentation framework—long enough for signal, short enough to kill fast. This is the same method behind [Focus projects](/projects/) at the studio: measured outcomes, then a scale, pivot, or kill decision.
 
 ## Why 12 Weeks?
 
@@ -348,11 +348,15 @@ The key is committing to the timeline and decision criteria upfront. This preven
 
 After running dozens of experiments through this framework, we've found it creates the perfect balance between thorough validation and rapid iteration—exactly what anonymous building requires.
 
+Today the framework runs behind the studio's Focus projects: [Parental Leave Planner](/projects/parental-leave-planner) and [The Hockey Analytics](/projects/the-hockey-analytics) apply the same continue/pivot/kill decision gates in production, with live status on the [portfolio](/projects/).
+
 ## Related Resources
 
 - **[Rapid Experimentation Frameworks](/insights/experimentation-frameworks)** — Complete guide to systematic business experimentation
 - **[Why Anonymity Accelerates Innovation](/posts/why-anonymity-accelerates-innovation)** — How anonymous building enables faster experimentation
 - **[AI as Co-Founder](/posts/ai-as-cofounder)** — How AI collaboration accelerates experiment cycles
+- **[Parental Leave Planner](/projects/parental-leave-planner)** — Focus project running the framework's continue/pivot/kill decision gates
+- **[The Hockey Analytics](/projects/the-hockey-analytics)** — Focus project applying the 12-week decision matrix to hockey intelligence
 
 ## FAQ: 12-Week Experiment Framework
 

--- a/src/content/posts/coolify-hetzner-automated-infrastructure.md
+++ b/src/content/posts/coolify-hetzner-automated-infrastructure.md
@@ -235,6 +235,7 @@ If you want to replicate this setup:
 - **[AI Tool Stack](/tools)** — Complete overview of all tools in our operating stack
 - **[Auto Agent Workflows](/insights/auto-agent-workflows)** — How agents interact with this infrastructure
 - **[Post-Human Venture Engine](/projects/post-human-venture-engine)** — The operating system this infrastructure powers
+- **[The Unnamed Roads studio](/projects/anonymous-venture-studio)** — the studio this infrastructure powers
 - **[Venture Studio Operations](/insights/venture-studio-operations)** — How we manage multiple ventures on this infrastructure
 
 ---

--- a/src/content/posts/field-note-three-focus-bets-2026-08-10.md
+++ b/src/content/posts/field-note-three-focus-bets-2026-08-10.md
@@ -19,9 +19,9 @@ We chose concentration.
 
 Exactly **three Focus projects**:
 
-1. **The Hockey Analytics** — Sweden Club Pack / league intelligence for club leaders
-2. **The Unnamed Roads** — Field Notes for indie founders (this channel)
-3. **Föräldraledighetsplaneraren** — Swedish parental-leave plans via SEO/AEO
+1. **[The Hockey Analytics](/projects/the-hockey-analytics)** — Sweden Club Pack / league intelligence for club leaders
+2. **[The Unnamed Roads](/projects/anonymous-venture-studio)** — Field Notes for indie founders (this channel)
+3. **[Föräldraledighetsplaneraren](/projects/parental-leave-planner)** — Swedish parental-leave plans via SEO/AEO
 
 Everything else is **Monitor** (measured, no daily growth execution) or **Parked**.
 

--- a/src/content/posts/mcp-protocol-explained.md
+++ b/src/content/posts/mcp-protocol-explained.md
@@ -11,7 +11,7 @@ In 2024, AI agent tool usage was a jungle. Every framework had its own way of de
 
 Then came the [Model Context Protocol (MCP)](https://modelcontextprotocol.io) — Anthropic’s open proposal for a universal way to expose tools and context to AI agents. In 2025, it gained adoption. In 2026, it’s becoming the **default layer** between AI agents and their world.
 
-At The Unnamed Roads we run a one-operator venture studio where agents draft inside policy and humans Approve before deploy. We’ve built 200+ agent pipelines on LangGraph, CrewAI, and custom orchestrators—and for the past six months, every new agent uses MCP for tool access. Not because it’s trendy, but because it **solves real production problems** in a studio that ships fast.
+At The Unnamed Roads we run a one-operator venture studio where agents draft inside policy and humans Approve before deploy. We’ve built 200+ agent pipelines on LangGraph, CrewAI, and custom orchestrators—and for the past six months, every new agent uses MCP for tool access. Not because it’s trendy, but because it **solves real production problems** in a studio that ships fast. The same decision sits behind [Operator Context](/projects/operator-context), our MCP-native portfolio surface for assistants, and the [MeshGuard](/projects/meshguard) permission layer that governs which tool calls need human approval.
 
 This post breaks down MCP: what it is, why it matters, how to implement it, and where it fits in a production architecture. No fluff. Just what works.
 
@@ -265,7 +265,7 @@ MCP isn’t just for tool access. It’s becoming the **universal context layer*
 - **LangChain**: Deep MCP integration allows LangChain apps to connect to any MCP server without code changes.
 - **Custom Orchestrators**: Teams building bespoke agent frameworks are adopting MCP as the internal wire protocol.
 
-We run our own AI stack on Hetzner Cloud, and our live agents are built with OpenClaw. We’ve integrated MCP at the gateway level — all external tool access flows through our MCP server. This gives us a single point for security, logging, and policy enforcement.
+We run our own AI stack on Hetzner Cloud, and our live agents are built with OpenClaw. We’ve integrated MCP at the gateway level — all external tool access flows through our MCP server. This gives us a single point for security, logging, and policy enforcement, and it is the same tool-access contract behind [The Agent Fabric](/projects/the-agent-fabric), our distributed agent infrastructure project.
 
 ## FAQ: Model Context Protocol
 

--- a/src/content/projects/anonymous-venture-studio.md
+++ b/src/content/projects/anonymous-venture-studio.md
@@ -45,6 +45,8 @@ Mission: "Engineer reality faster than bureaucracy can react."
 - **Concept to live site in 48 hours**
 - **Zero manual content creation**
 
+The infrastructure behind this site is covered in [How we run a fully automated infrastructure on Coolify and Hetzner](/posts/coolify-hetzner-automated-infrastructure); why the studio runs as one of three Focus bets is documented in [Field Note: Three Focus bets](/posts/field-note-three-focus-bets-2026-08-10).
+
 ## The Stack
 
 Coolify · Hetzner · n8n · OpenClaw · Umami · Minio · Groq · Gemini

--- a/src/content/projects/meshguard.md
+++ b/src/content/projects/meshguard.md
@@ -36,7 +36,7 @@ Agent stacks fail governance at scale when:
 - Tool access is all-or-nothing per API key
 - Approval levels live in chat prompts instead of enforceable policy
 - Consequential calls (publish, deploy, external send) lack a durable audit trail
-- MCP servers and automation runners share credentials without scoped allow-lists
+- [MCP](/posts/mcp-protocol-explained) servers and automation runners share credentials without scoped allow-lists
 
 MeshGuard targets the gap between **MethodPolicy roles** (Research, Draft, Execute, Publish) and the actual tools those roles may invoke.
 

--- a/src/content/projects/operator-context.md
+++ b/src/content/projects/operator-context.md
@@ -34,4 +34,6 @@ homepage:
 
 **Non-goals:** Autonomous sends, deploys, or policy changes from an assistant.
 
+**Protocol:** Built on the [Model Context Protocol](/posts/mcp-protocol-explained) the studio standardized on — the same decision behind every new studio agent.
+
 **Depends on:** TUR Company OS control plane, MeshGuard permission model, Signal Mesh ranked inputs.

--- a/src/content/projects/parental-leave-planner.md
+++ b/src/content/projects/parental-leave-planner.md
@@ -47,6 +47,8 @@ income and scenarios without needing to become experts in the rulebook.
 It already has organic traffic evidence and a concrete validation contract:
 complete leave plans, return/share rate, and Swedish problem-specific SEO/AEO.
 
+The contract runs on the studio's [12-week experimentation framework](/posts/12-week-experiment-framework): measured outcomes decide what ships next. Why this project holds a Focus slot instead of portfolio-wide SEO is documented in [Field Note: Three Focus bets](/posts/field-note-three-focus-bets-2026-08-10).
+
 ## What you get
 
 - Day and economy scenarios for two adults

--- a/src/content/projects/the-agent-fabric.md
+++ b/src/content/projects/the-agent-fabric.md
@@ -36,7 +36,7 @@ homepage:
 
 > **Part of our [Auto Agent Workflows](/insights/auto-agent-workflows) pillar** — This project provides the infrastructure layer for deploying autonomous AI agents at scale.
 
-The Agent Fabric provides the distributed, sovereign infrastructure layer that allows [post-human entrepreneurs](/posts/the-post-human-entrepreneur) to deploy AI agents inside enterprise systems—securely, locally, and at scale.
+The Agent Fabric provides the distributed, sovereign infrastructure layer that allows [post-human entrepreneurs](/posts/the-post-human-entrepreneur) to deploy AI agents inside enterprise systems—securely, locally, and at scale. Tool access across the fabric follows the [Model Context Protocol](/posts/mcp-protocol-explained) decision the studio standardized on.
 
 ## The Problem
 

--- a/src/content/projects/the-hockey-analytics.md
+++ b/src/content/projects/the-hockey-analytics.md
@@ -40,6 +40,8 @@ faq:
 
 Independent hockey analytics research and consulting from Stockholm. The core idea: continuously scan hockey data to detect patterns, anomalies, and opportunities proactively — surfacing insights before anyone else sees them.
 
+THA runs on the studio's [12-week experimentation framework](/posts/12-week-experiment-framework) — the Focus validation contract defines one falsifiable outcome per cycle. How THA keeps a Focus slot is documented in [Field Note: Three Focus bets](/posts/field-note-three-focus-bets-2026-08-10).
+
 ## What Makes It Different
 
 Most analytics tools are reactive. You ask a question, you get an answer. THA flips that — insights arrive unsolicited, based on ongoing pattern scanning across NHL data. Scouts and coaches get intelligence they didn't know to ask for.


### PR DESCRIPTION
Closing as superseded: #78 already completed via merged #156. This openhands/agent-issue-78 branch is now dirty against main and duplicate.