### PR TITLE
feat(seo): bidirectional Field Notes ↔ Focus project links (Closes #78)

### DIFF
--- a/src/content/posts/12-week-experiment-framework.md
+++ b/src/content/posts/12-week-experiment-framework.md
@@ -10,7 +10,7 @@ draft: false
 
 > **Studio Field Note** — Our [experimentation frameworks](/insights/experimentation-frameworks) pillar in practice: 4 bets per year, phase gates, and documented kill criteria from anonymous product tests.
 
-After dozens of anonymous product bets, we standardized on a 12-week experimentation framework—long enough for signal, short enough to kill fast. This is the same method behind Focus projects at the studio.
+After dozens of anonymous product bets, we standardized on a 12-week experimentation framework—long enough for signal, short enough to kill fast. This is the same method behind [Focus projects](/insights/focus-monitor-parked) at the studio—scale, pivot, or kill based on pre-committed criteria.
 
 ## Why 12 Weeks?
 
@@ -351,8 +351,12 @@ After running dozens of experiments through this framework, we've found it creat
 ## Related Resources
 
 - **[Rapid Experimentation Frameworks](/insights/experimentation-frameworks)** — Complete guide to systematic business experimentation
+- **[Focus · Monitor · Parked](/insights/focus-monitor-parked)** — How this framework feeds the studio's portfolio allocation decisions
 - **[Why Anonymity Accelerates Innovation](/posts/why-anonymity-accelerates-innovation)** — How anonymous building enables faster experimentation
 - **[AI as Co-Founder](/posts/ai-as-cofounder)** — How AI collaboration accelerates experiment cycles
+- **[The Hockey Analytics](/projects/the-hockey-analytics)** — Focus project validated with this framework
+- **[Parental Leave Planner](/projects/parental-leave-planner)** — Focus project run through this framework
+- **[The Unnamed Roads](/projects/anonymous-venture-studio)** — Studio Focus project running these experiments
 
 ## FAQ: 12-Week Experiment Framework
 

--- a/src/content/posts/field-note-mobile-focus-control-2026-08-12.md
+++ b/src/content/posts/field-note-mobile-focus-control-2026-08-12.md
@@ -28,9 +28,9 @@ PostHog notes and next reach actions are visible before you approve a deploy.
 
 ## Focus projects this cycle
 
-- **Parental** — FAQ/AEO for *planera dagar* → planner CTA (`/guide/planera-foraldraledighet`)
-- **THA** — Sweden Club Pack one-pager with assistant-readable beta brief
-- **TUR Studio** — Field Notes + service offer (this channel)
+- **[Parental](/projects/parental-leave-planner)** — FAQ/AEO for *planera dagar* → planner CTA (`/guide/planera-foraldraledighet`)
+- **[THA](/projects/the-hockey-analytics)** — Sweden Club Pack one-pager with assistant-readable beta brief
+- **[TUR Studio](/projects/anonymous-venture-studio)** — Field Notes + service offer (this channel)
 - **Company OS** — Signal Mesh v0 → ranked decisions in Linear
 
 Everything else stays **Monitor** or **Parked**.

--- a/src/content/posts/field-note-three-focus-bets-2026-08-10.md
+++ b/src/content/posts/field-note-three-focus-bets-2026-08-10.md
@@ -19,9 +19,9 @@ We chose concentration.
 
 Exactly **three Focus projects**:
 
-1. **The Hockey Analytics** — Sweden Club Pack / league intelligence for club leaders
-2. **The Unnamed Roads** — Field Notes for indie founders (this channel)
-3. **Föräldraledighetsplaneraren** — Swedish parental-leave plans via SEO/AEO
+1. **[The Hockey Analytics](/projects/the-hockey-analytics)** — Sweden Club Pack / league intelligence for club leaders
+2. **[The Unnamed Roads](/projects/anonymous-venture-studio)** — Field Notes for indie founders (this channel)
+3. **[Föräldraledighetsplaneraren](/projects/parental-leave-planner)** — Swedish parental-leave plans via SEO/AEO
 
 Everything else is **Monitor** (measured, no daily growth execution) or **Parked**.
 

--- a/src/content/posts/mcp-protocol-explained.md
+++ b/src/content/posts/mcp-protocol-explained.md
@@ -11,7 +11,7 @@ In 2024, AI agent tool usage was a jungle. Every framework had its own way of de
 
 Then came the [Model Context Protocol (MCP)](https://modelcontextprotocol.io) — Anthropic’s open proposal for a universal way to expose tools and context to AI agents. In 2025, it gained adoption. In 2026, it’s becoming the **default layer** between AI agents and their world.
 
-At The Unnamed Roads we run a one-operator venture studio where agents draft inside policy and humans Approve before deploy. We’ve built 200+ agent pipelines on LangGraph, CrewAI, and custom orchestrators—and for the past six months, every new agent uses MCP for tool access. Not because it’s trendy, but because it **solves real production problems** in a studio that ships fast.
+At [The Unnamed Roads](/projects/anonymous-venture-studio) we run a one-operator venture studio where agents draft inside policy and humans Approve before deploy. We’ve built 200+ agent pipelines on LangGraph, CrewAI, and custom orchestrators—and for the past six months, every new agent uses MCP for tool access. Not because it’s trendy, but because it **solves real production problems** in a studio that ships fast.
 
 This post breaks down MCP: what it is, why it matters, how to implement it, and where it fits in a production architecture. No fluff. Just what works.
 
@@ -282,7 +282,13 @@ Yes, but with caveats. Major platforms like LangChain and LiteLLM support it. Pr
 MCP supports file streaming via multipart form data or signed URLs. For large payloads, we recommend using references — e.g., `"file_id": "doc_123"` — and letting the client fetch the actual content separately.
 
 ### Where can I see real-world MCP examples?
-The official [MCP GitHub repo](https://github.com/anthropics/mcp) has examples. We’ll be publishing our production MCP server templates on [The Agent Fabric](https://theagentfabric.com) soon.
+The official [MCP GitHub repo](https://github.com/anthropics/mcp) has examples. We’ll be publishing our production MCP server templates on [The Agent Fabric](https://theagentfabric.com) — the studio's [agent infrastructure project](/projects/the-agent-fabric) — soon.
 
 ---
 *Building AI agents in production? I cover real architectures, mistakes, and wins in the newsletter — [subscribe here](https://theagentfabric.com/newsletter).*
+
+## Related Resources
+
+- **[The Agent Fabric](/projects/the-agent-fabric)** — Studio project running agent infrastructure on MCP
+- **[The Unnamed Roads](/projects/anonymous-venture-studio)** — The venture studio where every new agent uses MCP
+- **[Auto Agent Workflows](/insights/auto-agent-workflows)** — The pillar this production pattern belongs to

--- a/src/content/projects/anonymous-venture-studio.md
+++ b/src/content/projects/anonymous-venture-studio.md
@@ -62,3 +62,8 @@ Coolify · Hetzner · n8n · OpenClaw · Umami · Minio · Groq · Gemini
 ## Operating Principle
 
 Build without permission. Ship without a team. Let the data decide what survives.
+
+## Field Notes
+
+- [12-Week Experimentation Framework](/posts/12-week-experiment-framework) — the studio method behind every Focus bet
+- [MCP Explained](/posts/mcp-protocol-explained) — how the studio's 200+ agent pipelines get tool access

--- a/src/content/projects/parental-leave-planner.md
+++ b/src/content/projects/parental-leave-planner.md
@@ -52,3 +52,8 @@ complete leave plans, return/share rate, and Swedish problem-specific SEO/AEO.
 - Day and economy scenarios for two adults
 - Shareable plan results
 - Partner surfaces for relevant family support (GDPR-aware)
+
+## Field Notes
+
+- [12-Week Experimentation Framework](/posts/12-week-experiment-framework) — the studio method behind this Focus validation contract
+- [Field Note: Three Focus bets](/posts/field-note-three-focus-bets-2026-08-10) — why Föräldraledighetsplaneraren runs as one of the studio's three Focus bets (personal note by Emil Ingemar Karlsson)

--- a/src/content/projects/the-agent-fabric.md
+++ b/src/content/projects/the-agent-fabric.md
@@ -34,7 +34,7 @@ homepage:
 
 **Orchestrating distributed intelligence across data centers, edge nodes, and IoT devices.**
 
-> **Part of our [Auto Agent Workflows](/insights/auto-agent-workflows) pillar** — This project provides the infrastructure layer for deploying autonomous AI agents at scale.
+> **Part of our [Auto Agent Workflows](/insights/auto-agent-workflows) pillar** — This project provides the infrastructure layer for deploying autonomous AI agents at scale. Field note: [MCP Explained](/posts/mcp-protocol-explained) documents how agents get tool access in this stack.
 
 The Agent Fabric provides the distributed, sovereign infrastructure layer that allows [post-human entrepreneurs](/posts/the-post-human-entrepreneur) to deploy AI agents inside enterprise systems—securely, locally, and at scale.
 

--- a/src/content/projects/the-hockey-analytics.md
+++ b/src/content/projects/the-hockey-analytics.md
@@ -63,3 +63,8 @@ Most analytics tools are reactive. You ask a question, you get an answer. THA fl
 Scouts, coaches, analysts, teams, and decision-makers who want a data edge in player development, roster construction, and game strategy.
 
 **Location:** Stockholm, Sweden · contact@thehockeyanalytics.com
+
+## Field Notes
+
+- [12-Week Experimentation Framework](/posts/12-week-experiment-framework) — the studio method behind this Focus validation contract
+- [Field Note: Three Focus bets](/posts/field-note-three-focus-bets-2026-08-10) — why THA runs as one of the studio's three Focus bets (personal note by Emil Ingemar Karlsson)


### PR DESCRIPTION
## Summary

Closes #78 — internal links between Field Notes and Focus projects so crawlers/assistants follow studio proof trails. Link placement only; no brand/copy rewrite.

## Changes

**Top Field Notes → relevant Focus + decision language**
- [`12-week-experiment-framework`](/posts/12-week-experiment-framework): contextual link to [Focus · Monitor · Parked](/insights/focus-monitor-parked) with scale/pivot/kill decision language; Related Resources now link out to Focus projects (The Hockey Analytics, Parental Leave Planner, The Unnamed Roads)
- [`mcp-protocol-explained`](/posts/mcp-protocol-explained): links to The Unnamed Roads studio + The Agent Fabric project (was an orphan FN with no studio context)

**Focus pages → supporting Field Notes**
- The Hockey Analytics: Field Notes section → 12-Week Framework + "Three Focus bets" (EIK personal, labeled)
- Parental Leave Planner: Field Notes section → 12-Week Framework + "Three Focus bets" (EIK personal, labeled)
- The Unnamed Roads (studio): Field Notes section → 12-Week Framework + MCP Explained
- The Agent Fabric: inline link → MCP Explained

**Bidirectional closure on field-note posts**
- `field-note-three-focus-bets-2026-08-10` + `field-note-mobile-focus-control-2026-08-12`: Focus project lists now link back to the three Focus project pages

## Verification

- [x] `pnpm check` — 0 errors / 0 warnings / 0 hints
- [x] `pnpm build` — 181 pages indexed, no errors
- [x] Bidirectional links verified in built HTML for all chosen pairs
- [x] EIK personal Field Notes carefully labeled ("personal note by Emil Ingemar Karlsson")

## Scope note

- Minimal implementation — links only, no copy/brand changes
- Fence respected: TUR ≠ EIK ≠ THA ≠ Brain (Spelling "Ingemar"), no hire-funnel/LinkedIn content added
- Never merge — human approval required

@emilingemarkarlsson can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8c54e25f-0d72-4892-9979-bebce49f2e37)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown content and internal URLs only; no application logic, auth, or data handling changes.
> 
> **Overview**
> Adds **bidirectional internal links** between studio Field Notes posts and Focus project pages so crawlers and assistants can follow methodology ↔ product proof trails. Link placement only—no substantive copy rewrites.
> 
> **Posts → projects:** The 12-week framework post now links to Focus · Monitor · Parked and lists THA, Parental Leave Planner, and TUR studio in Related Resources; MCP Explained links the studio and Agent Fabric and gains a Related Resources block; the two August 2026 field notes turn Focus project names into `/projects/*` links.
> 
> **Projects → posts:** THA, Parental Leave Planner, and The Unnamed Roads gain **Field Notes** sections pointing at the 12-week framework and relevant field notes (personal EIK notes labeled); Agent Fabric’s pillar callout links to MCP Explained.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daa72ff1cf08a107d018b18cd17bcf27f07d5ef1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->